### PR TITLE
Add rope_scaling support for LLama3.1

### DIFF
--- a/vllm_hpu_extension/rotary_embed.py
+++ b/vllm_hpu_extension/rotary_embed.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 ###############################################################################
 
+import math
 import torch
 import torch.nn as nn
 
@@ -29,22 +30,21 @@ class HpuRotaryEmbedding(nn.Module):
                  base=10000,
                  is_neox_style=None,
                  device='hpu',
-                 RoPEFallback=None):
+                 RoPEFallback=None,
+                 skip_fallback=False):
         super().__init__()
 
         self.head_size = head_size
         self.dim = rotary_dim
         self.max_position_embeddings = max_position_embeddings
         self.base = base
-        inv_freq = 1.0 / (self.base**(
-            torch.arange(0, self.dim, 2).float().to(device) / self.dim))
-        self.register_buffer("inv_freq", inv_freq, persistent=False)
+        self.device = device
 
         # Build here to make `torch.jit.trace` work.
         self._set_cos_sin_cache(seq_len=max_position_embeddings,
-                                device=self.inv_freq.device,
+                                device=device,
                                 dtype=torch.get_default_dtype())
-        if FusedRoPE is None:
+        if FusedRoPE is None and not skip_fallback:
             assert RoPEFallback is not None, (
                 "HPU FusedRoPE kernel could not be imported, and "
                 "fallback RoPE implementation was not provided!")
@@ -55,13 +55,20 @@ class HpuRotaryEmbedding(nn.Module):
                                               is_neox_style,
                                               dtype=torch.get_default_dtype())
 
+    def _compute_inv_freq(self) -> torch.Tensor:
+        inv_freq = 1.0 / (self.base**(
+            torch.arange(0, self.dim, 2).float().to(self.device) / self.dim))
+        return inv_freq
+
     def _set_cos_sin_cache(self, seq_len, device, dtype):
         self.max_seq_len_cached = seq_len
+
+        inv_freq = self._compute_inv_freq()
         t = torch.arange(self.max_seq_len_cached,
                          device=device,
-                         dtype=self.inv_freq.dtype)
+                         dtype=inv_freq.dtype)
 
-        freqs = torch.einsum("i,j->ij", t, self.inv_freq)
+        freqs = torch.einsum("i,j->ij", t, inv_freq)
         # Different from paper, but it uses a different permutation in order
         # to obtain the same calculation
         emb = torch.cat((freqs, freqs), dim=-1)
@@ -116,3 +123,64 @@ class HpuRotaryEmbedding(nn.Module):
             (query.shape[0], query.shape[1],
              query.shape[2] * query.shape[3])), key.reshape(
                  (key.shape[0], key.shape[1], key.shape[2] * key.shape[3]))
+
+
+class HpuLlama3RotaryEmbedding(HpuRotaryEmbedding):
+
+    def __init__(self,
+                 head_size: int,
+                 rotary_dim: int,
+                 max_position_embeddings: int,
+                 base: int,
+                 is_neox_style: bool,
+                 scaling_factor: float,
+                 low_freq_factor: float,
+                 high_freq_factor: float,
+                 orig_max_position: int,
+                 device="hpu",
+                 RoPEFallback=None):
+
+        self.scaling_factor = scaling_factor
+        self.low_freq_factor = low_freq_factor
+        self.high_freq_factor = high_freq_factor
+        self.orig_max_position = orig_max_position
+        super().__init__(head_size, rotary_dim, max_position_embeddings,
+                         base, is_neox_style, device, RoPEFallback, skip_fallback=True)
+
+        if FusedRoPE is None:
+            assert RoPEFallback is not None, (
+                "HPU FusedRoPE kernel could not be imported, and "
+                "fallback RoPE implementation was not provided!")
+            self.fallback_impl = RoPEFallback(head_size,
+                                              rotary_dim,
+                                              max_position_embeddings,
+                                              base,
+                                              is_neox_style,
+                                              torch.get_default_dtype(),
+                                              scaling_factor,
+                                              low_freq_factor,
+                                              high_freq_factor,
+                                              orig_max_position)
+
+    def _compute_inv_freq(self) -> torch.Tensor:
+        inv_freqs = super()._compute_inv_freq()
+        low_freq_wavelen = self.orig_max_position / self.low_freq_factor
+        high_freq_wavelen = self.orig_max_position / self.high_freq_factor
+
+        wave_len = 2 * math.pi / inv_freqs
+        if self.low_freq_factor != self.high_freq_factor:
+            smooth = (self.orig_max_position / wave_len - self.low_freq_factor
+                      ) / (self.high_freq_factor - self.low_freq_factor)
+        else:
+            smooth = 0
+        new_freqs = torch.where(
+            wave_len < high_freq_wavelen,
+            inv_freqs,
+            torch.where(
+                wave_len > low_freq_wavelen,
+                inv_freqs / self.scaling_factor,
+                (1 - smooth) * inv_freqs / self.scaling_factor +
+                smooth * inv_freqs,
+            ),
+        )
+        return new_freqs


### PR DESCRIPTION
Since LLama3.1 additional rope scaling was added which was not handled by our RotaryEmbedding implementation. Due to that FusedRoPE was not used.
This PR adds `HpuLlama3RotaryEmbedding` based on the [Llama3RotaryEmbedding](https://github.com/HabanaAI/vllm-fork/blob/habana_main/vllm/model_executor/layers/rotary_embedding.py#L673) which allows to use scaling and FusedRoPE together.