### PR TITLE
Softmax: add weighted-sum normalization

### DIFF
--- a/vllm_hpu_extension/ops.py
+++ b/vllm_hpu_extension/ops.py
@@ -46,7 +46,8 @@ def block2batch(tensor, block_mapping):
 
 
 def normalize_amax(attn):
-    attn_max = attn.amax(-1, keepdim=True)
+    tail_dims = tuple(range(1, attn.dim()))
+    attn_max = attn.amax(tail_dims).amax()
     return attn.sub_(attn_max)
 
 

--- a/vllm_hpu_extension/ops.py
+++ b/vllm_hpu_extension/ops.py
@@ -71,9 +71,10 @@ def block_softmax(batch_size, attn, block_mapping, block_scales):
     attn = normalize(batch_size=batch_size, attn=attn, block_mapping=block_mapping, block_scales=block_scales)
     attn = attn.exp_()
     sums = attn.sum(dim=-1).unsqueeze(-1)
+    block_sum = sums
     sums = block2batch(sums, block_mapping)
     sums = batch2block(sums, block_mapping)
-    sums.add_(torch.finfo(sums.dtype).tiny)
+    sums = torch.maximum(block_sum, sums)
     attn.div_(sums)
     return attn
 

--- a/vllm_hpu_extension/ops.py
+++ b/vllm_hpu_extension/ops.py
@@ -8,7 +8,6 @@ from typing import Optional, Tuple
 
 import habana_frameworks.torch as htorch
 import torch
-import math
 import os
 import torch.nn.functional as F
 


### PR DESCRIPTION
This introduces another algorithm for softmax normalization - wsum (weighted sum).
The main idea is that we can normalize softmax values by a weighted sum of the local block maximums, i.e. a = sum(w * max(attn)). In most cases the weights (or block_scales) are selected so be equal to 1/num_blocks so that the sum doesn't explode with a larger number of blocks.