### PR TITLE
add: migrate changes for prefix caching from vllm repository

### DIFF
--- a/vllm_hpu_extension/cache_ops.py
+++ b/vllm_hpu_extension/cache_ops.py
@@ -18,33 +18,30 @@ def insert_or_update_cache(input, cache, block_indices, block_offsets):
         cache.index_put_((block_indices, block_offsets), input)
 
 def swap_blocks(src, dst, block_mapping):
-    index_src = torch.zeros((1, ), dtype=torch.int32, device=src.device)
-    index_dst = torch.zeros((1, ), dtype=torch.int32, device=dst.device)
-    for src_idx, dst_idx in block_mapping.items():
-        index_src[0] = src_idx
-        index_dst[0] = dst_idx
-        dst.index_put_([index_dst], src.index_select(0, index_src))
-    if dst.device.type == 'hpu':
-        htorch.core.mark_step()
-        torch.hpu.synchronize()
+    if block_mapping.numel() == 0:
+        return
+
+    block_mapping = block_mapping.transpose(0, 1)
+    src_indices = block_mapping[0]
+    dst_indices = block_mapping[1]
+
+    dst.index_put_(dst_indices, src.index_select(0, src_indices))
+
+    htorch.core.mark_step()
+    torch.hpu.synchronize()
 
 
 def copy_blocks(key_caches, value_caches, block_mapping):
-    index_src = torch.zeros((1, ),
-                            dtype=torch.int32,
-                            device=key_caches[0].device)
-    index_dst = torch.zeros((1, ),
-                            dtype=torch.int32,
-                            device=key_caches[0].device)
-    for src, dsts in block_mapping.items():
-        index_src[0] = src
-        for dst in dsts:
-            index_dst[0] = dst
-            for key_cache in key_caches:
-                key_cache.index_copy_(0, index_dst,
-                                      key_cache.index_select(0, index_src))
-            for value_cache in value_caches:
-                value_cache.index_copy_(0, index_dst,
-                                        value_cache.index_select(0, index_src))
-        if key_caches[0].device.type == 'hpu':
-            htorch.core.mark_step()
+    if block_mapping.numel() == 0:
+        return
+
+    block_mapping = block_mapping.transpose(0, 1)
+    src = block_mapping[0]
+    dst = block_mapping[1]
+
+    for key_cache, value_cache in zip(key_caches, value_caches):
+        key_cache.index_copy_(0, dst, key_cache.index_select(0, src))
+        value_cache.index_copy_(0, dst, value_cache.index_select(0, src))
+
+    if key_caches[0].device.type == 'hpu':
+        htorch.core.mark_step()

--- a/vllm_hpu_extension/ops.py
+++ b/vllm_hpu_extension/ops.py
@@ -157,6 +157,64 @@ def prompt_attention(
     return attn_weights
 
 
+def prompt_attention_with_context(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    key_cache: torch.Tensor,
+    value_cache: torch.Tensor,
+    block_list: torch.Tensor,
+    attn_bias: torch.Tensor,
+    scale: float,
+    matmul_qk_op,
+    matmul_av_op,
+    softmax_op,
+    keys_fetch_func,
+    values_fetch_func, 
+) -> torch.Tensor:
+    htorch.core.mark_step()
+    query.mul_(scale)
+
+    batch_size, _, query_heads, _ = query.shape
+    _, block_size, kv_heads, _ = key_cache.shape
+    max_num_blocks = block_list.size(-1) // batch_size
+    context_len = max_num_blocks * block_size
+
+    query = query.transpose(1, 2)
+    key = key.transpose(1, 2)
+    value = value.transpose(1, 2)
+
+    past_keys = keys_fetch_func(key_cache, block_list)
+    past_keys = past_keys.reshape(batch_size, context_len, kv_heads, -1)
+    past_keys = past_keys.transpose(1, 2)
+    key = torch.concat((past_keys, key), dim=-2)
+
+    past_values = values_fetch_func(value_cache, block_list)
+    past_values = past_values.reshape(batch_size, context_len, kv_heads, -1)
+    past_values = past_values.transpose(1, 2)
+    value = torch.concat((past_values, value), dim=-2)
+
+    if query_heads != kv_heads:
+        query = query.unflatten(1, (kv_heads, -1))
+        key = key.unflatten(1, (kv_heads, 1))
+        past_keys = past_keys.unflatten(1, (kv_heads, 1))
+        value = value.unflatten(1, (kv_heads, 1))
+        past_values = past_values.unflatten(1, (kv_heads, 1))
+        attn_bias = attn_bias.unsqueeze(2)
+
+    attn_weights = matmul_qk_op(query, key.transpose(-1, -2))
+    attn_weights.add_(attn_bias)
+    attn_weights = softmax_op(attn_weights, dim=-1)
+    attn_weights = matmul_av_op(attn_weights, value)
+
+    if query_heads != kv_heads:
+        attn_weights = attn_weights.flatten(1, 2)
+
+    attn_weights = attn_weights.transpose(1, 2)
+    htorch.core.mark_step()
+    return attn_weights
+
+
 class LoraMask:
     lora_mask = None
 

--- a/vllm_hpu_extension/rotary_embed.py
+++ b/vllm_hpu_extension/rotary_embed.py
@@ -81,48 +81,29 @@ class HpuRotaryEmbedding(nn.Module):
 
     def forward(self, positions: torch.Tensor, query: torch.Tensor,
                 key: torch.Tensor):
-        if FusedRoPE is None:
-            return self.fallback_impl(positions, query, key)
-        if query.dim() == 2:
-            query = query.unsqueeze(0)
-        if key.dim() == 2:
-            key = key.unsqueeze(0)
-        if positions.dim() == 1:
-            positions = positions.unsqueeze(0)
-        seq_len = key.shape[-2]
-        if seq_len > self.max_seq_len_cached:
-            self._set_cos_sin_cache(seq_len=seq_len,
-                                    device=query.device,
-                                    dtype=query.dtype)
+            if FusedRoPE is None:
+                return self.fallback_impl(positions, query, key)
+            if query.dim() == 2:
+                query = query.unsqueeze(0)
+            if key.dim() == 2:
+                key = key.unsqueeze(0)
+            if positions.dim() == 1:
+                positions = positions.unsqueeze(0)
 
-        cos, sin = self.cos_cached[:seq_len].to(
-            dtype=query.dtype), self.sin_cached[:seq_len].to(dtype=query.dtype)
-        query = query.reshape(
-            (query.shape[0], query.shape[1], query.shape[2] // self.head_size,
-             self.head_size))
-        key = key.reshape((key.shape[0], key.shape[1],
-                           key.shape[2] // self.head_size, self.head_size))
-        query_rot = query[..., :self.dim]
-        key_rot = key[..., :self.dim]
-        if self.dim < self.head_size:
-            query_pass = query[..., self.dim:]
-            key_pass = key[..., self.dim:]
+            query = query.reshape(
+                (query.shape[0], query.shape[1], query.shape[2] // self.head_size,
+                self.head_size))
+            key = key.reshape((key.shape[0], key.shape[1],
+                            key.shape[2] // self.head_size, self.head_size))
 
-        if len(positions[0]) == 1:
             cos = self.cos_cached[positions].unsqueeze(2).to(dtype=query.dtype)
             sin = self.sin_cached[positions].unsqueeze(2).to(dtype=query.dtype)
-        else:
-            cos = cos[positions].unsqueeze(2)
-            sin = sin[positions].unsqueeze(2)
-        query, key = FusedRoPE.apply(query_rot, cos, sin,
-                                     0), FusedRoPE.apply(key_rot, cos, sin, 0)
-        if self.dim < self.head_size:
-            query = torch.cat((query, query_pass), dim=-1)
-            key = torch.cat((key, key_pass), dim=-1)
-        return query.reshape(
-            (query.shape[0], query.shape[1],
-             query.shape[2] * query.shape[3])), key.reshape(
-                 (key.shape[0], key.shape[1], key.shape[2] * key.shape[3]))
+            query = FusedRoPE.apply(query, cos, sin, 0)
+            key = FusedRoPE.apply(key, cos, sin, 0)
+            return query.reshape(
+                (query.shape[0], query.shape[1],
+                query.shape[2] * query.shape[3])), key.reshape(
+                    (key.shape[0], key.shape[1], key.shape[2] * key.shape[3]))
 
 
 class HpuLlama3RotaryEmbedding(HpuRotaryEmbedding):


### PR DESCRIPTION
migrating some parts of [PR in vllm-fork](https://github.com/HabanaAI/vllm-fork/pull/162)

changes:
* changes on rope forward to work well(fast) with context
* updated deprecated cache ops to work (block mapping has changed from dict to tensor)
* added prompt_attention_with_context for prefill with context(cached prefix)

will update the main PR in vllm-fork too.