### PR TITLE
Add DynamicFusedMOE (move from vllm-fork)

### DIFF
--- a/vllm_hpu_extension/ops.py
+++ b/vllm_hpu_extension/ops.py
@@ -320,6 +320,16 @@ class MoeMatmul(torch.nn.Module):
         return torch.matmul(state, w[expert_id].transpose(0, 1))
 
 
+def calculate_routing_tensors(score, topk, hidden_states_dtype):
+    routing_weights = F.softmax(score, dim=1, dtype=torch.float32)
+    routing_weights, selected_experts = torch.topk(routing_weights,
+                                                   topk,
+                                                   dim=-1)
+    routing_weights /= routing_weights.sum(dim=-1, keepdim=True)
+    routing_weights = routing_weights.to(hidden_states_dtype)
+    return routing_weights, selected_experts
+
+
 class StaticFusedMOE(torch.nn.Module):
 
     def __init__(self, num_total_experts):
@@ -332,12 +342,8 @@ class StaticFusedMOE(torch.nn.Module):
 
     def forward(self, hidden_states, w1, w2, score, topk):
         B, D = hidden_states.shape
-        routing_weights = F.softmax(score, dim=1, dtype=torch.float32)
-        routing_weights, selected_experts = torch.topk(routing_weights,
-                                                       topk,
-                                                       dim=-1)
-        routing_weights /= routing_weights.sum(dim=-1, keepdim=True)
-        routing_weights = routing_weights.to(hidden_states.dtype)
+        routing_weights, selected_experts = calculate_routing_tensors(
+                        score, topk, hidden_states.dtype)
         final_hidden_states = torch.zeros((1, B, D),
                                           dtype=hidden_states.dtype,
                                           device=hidden_states.device)
@@ -359,6 +365,37 @@ class StaticFusedMOE(torch.nn.Module):
             final_hidden_states += current_hidden_states_static
 
         return final_hidden_states.view(-1, D)
+
+
+class DynamicFusedMOE(torch.nn.Module):
+
+    def __init__(self, num_total_experts):
+        super().__init__()
+        self.num_total_experts = num_total_experts
+
+    def forward(self, hidden_states, w1, w2, score, topk):
+        htorch.core.mark_step()
+        routing_weights, selected_experts = calculate_routing_tensors(
+                score, topk, hidden_states.dtype)
+        # pre-processing for custom op inputs
+        experts_range = range(self.num_total_experts)
+        w1_list = [w1[i,:,:].squeeze() for i in experts_range]
+        w2_list = [w2[i,:,:].squeeze() for i in experts_range]
+
+        final_hidden_states = torch.ops.hpu.mixture_of_experts(
+                hidden_states=hidden_states,
+                expert_routing_table=selected_experts,
+                router_weights=routing_weights,
+                w12=w1_list,
+                w3=w2_list,
+                permuted_weights=True,
+                activation="silu",
+                experts_min=0,
+                experts_max=7
+        )
+
+        return final_hidden_states.view(-1, hidden_states.shape[1])
+
 
 # fp8
 def scaled_fp8_quant(


### PR DESCRIPTION
Moving part of Dynamic MoE implementation that was a part of [vllm/hpu/ops.py](https://github.com/HabanaAI/vllm-fork/pull/303/files#diff-bd4586975c8131c8c80c2103554f75f014ce5d50216126821127a2ea31d96502) in HabanaAI/vllm-fork repository.

https://github.com/HabanaAI/vllm-fork/pull/303