### PR TITLE
Add support for various softmax normalization options

### DIFF
--- a/vllm_hpu_extension/ops.py
+++ b/vllm_hpu_extension/ops.py
@@ -81,12 +81,8 @@ class SoftmaxNormalization:
         block_sum_attn = block2batch(block_sum_attn, block_mapping)
         block_sum_attn = batch2block(block_sum_attn, block_mapping)
         attn.sub_(block_sum_attn.unsqueeze(-1))
-        if True:
-            dims = tuple(range(1, attn.dim()))
-            attn_max = attn.amax(dims).amax()
-        else:
-            attn_max = attn_max.sub_(block_sum_attn.amax())
-        return attn.sub_(attn_max)
+        attn_max.sub_(block_sum_attn)
+        return attn.sub_(attn_max.amax())
 
     @staticmethod
     def index_reduce(attn, batch_size, block_groups, **rest):


### PR DESCRIPTION
Adds support for selecting softmax normalization algorithm (via VLLM_PA_SOFTMAX_IMPL):
  'wsum'
  'amax'
  'head_amax'
  'wsum_head_amax'
  'index_reduce'
  'scatter_reduce'

'wsum_head_amax' is selected by default as it should help with Qwen2 accuracy issues.