### PR TITLE
Contiguous PA

### DIFF
--- a/vllm_hpu_extension/utils.py
+++ b/vllm_hpu_extension/utils.py
@@ -60,4 +60,4 @@ class VLLMKVCache(torch.nn.Module):
         return cache
 
     def fetch_from_cache(self, cache, blocks):
-        return cache.index_select(0, blocks)
+        return cache[:blocks.size(0)]

--- a/vllm_hpu_extension/utils.py
+++ b/vllm_hpu_extension/utils.py
@@ -54,10 +54,16 @@ class VLLMKVCache(torch.nn.Module):
 
     def __init__(self):
         super(VLLMKVCache, self).__init__()
+        self.use_contiguous_pa = os.environ.get('VLLM_CONTIGUOUS_PA',
+                                                'false').lower() == 'true'
 
     def forward(self, input, cache, block_indices, block_offset):
         insert_or_update_cache(input, cache, block_indices, block_offset)
         return cache
 
     def fetch_from_cache(self, cache, blocks):
-        return cache[:blocks.size(0)]
+        if self.use_contiguous_pa:
+            return cache[:blocks.size(0)]
+        else:
+            return cache.index_select(0, blocks)
+


### PR DESCRIPTION
Contiguous fetch from cache to avoid using costly gather operations. Requires changes made to hpu_model_runner in vllm-fork to work. Introduces redundant calculations in decoding phase. In all tested cases improves performance over the entire run. For even better performance cache defragmentation is required.