### PR TITLE
Implement capability checking

### DIFF
--- a/vllm_hpu_extension/capabilities.py
+++ b/vllm_hpu_extension/capabilities.py
@@ -1,0 +1,48 @@
+###############################################################################
+# Copyright (C) 2024 Habana Labs, Ltd. an Intel Company
+#
+# This source code is licensed under the Apache 2.0 license found in the
+# LICENSE file in the root directory of this source tree.
+###############################################################################
+
+from packaging.version import Version
+from packaging.specifiers import SpecifierSet
+from functools import cache
+
+from vllm_hpu_extension.environment import get_environment
+
+
+class VersionRange:
+    def __init__(self, *specifiers):
+        self.specifiers = [SpecifierSet(s) for s in specifiers]
+
+    def __call__(self, build, **_):
+        version = Version(build)
+        return any(version in s for s in self.specifiers)
+
+
+class Capabilities:
+    def __init__(self, features, environment):
+        self.all = set(features.keys())
+        self.enabled = set(name for name, check in features.items() if check(**environment))
+
+    def is_enabled(self, *names):
+        return all(n in self.enabled for n in names)
+
+    def __repr__(self):
+        feature_list = [('+' if self.is_enabled(f) else '-') + f for f in sorted(self.all)]
+        return f'[{(" ").join(feature_list)}]'
+
+    def __contains__(self, names):
+        return self.is_enabled(*names.split(','))
+
+
+@cache
+def capabilities():
+    supported_features = {
+        "index_copy": VersionRange(">=1.19.0-272"),
+    }
+    environment = get_environment()
+    capabilities = Capabilities(supported_features, environment)
+    print(f'Detected capabilities: {capabilities}')
+    return capabilities

--- a/vllm_hpu_extension/capabilities.py
+++ b/vllm_hpu_extension/capabilities.py
@@ -48,7 +48,7 @@ class Capabilities:
 @cache
 def capabilities():
     supported_features = {
-        "index_copy": VersionRange(">=1.19.0.272"),
+        "index_reduce": VersionRange(">=1.19.0.272"),
         "gaudi": Hardware("gaudi"),
         "gaudi2": Hardware("gaudi2"),
         "gaudi3": Hardware("gaudi3"),

--- a/vllm_hpu_extension/capabilities.py
+++ b/vllm_hpu_extension/capabilities.py
@@ -21,6 +21,14 @@ class VersionRange:
         return any(version in s for s in self.specifiers)
 
 
+class Hardware:
+    def __init__(self, target_hw):
+        self.target_hw = target_hw
+
+    def __call__(self, hw, **_):
+        return hw == self.target_hw
+
+
 class Capabilities:
     def __init__(self, features, environment):
         self.all = set(features.keys())
@@ -40,7 +48,10 @@ class Capabilities:
 @cache
 def capabilities():
     supported_features = {
-        "index_copy": VersionRange(">=1.19.0-272"),
+        "index_copy": VersionRange(">=1.19.0.272"),
+        "gaudi": Hardware("gaudi"),
+        "gaudi2": Hardware("gaudi2"),
+        "gaudi3": Hardware("gaudi3"),
     }
     environment = get_environment()
     capabilities = Capabilities(supported_features, environment)

--- a/vllm_hpu_extension/environment.py
+++ b/vllm_hpu_extension/environment.py
@@ -1,0 +1,30 @@
+###############################################################################
+# Copyright (C) 2024 Habana Labs, Ltd. an Intel Company
+#
+# This source code is licensed under the Apache 2.0 license found in the
+# LICENSE file in the root directory of this source tree.
+###############################################################################
+
+from pathlib import Path
+import re
+
+
+def get_build():
+    import habana_frameworks.torch as htorch
+    # This is ugly as hell, but it's the only reliable way of querying build number
+    # from python that doesn't involve parsing external process output.
+    # version.py can be found in gpu-migration package which means we cannot load it
+    # directly as this would trigger enabling that feature. Instead we parse the file.
+    version_re = re.compile(r'__version__\s+=\s+"(?P<version>.+)"')
+    path = Path(htorch.__file__).parent
+    for p in path.rglob("version.py"):
+        if m := version_re.search(open(p).read()):
+            return m.group('version')
+
+
+def get_environment(**overrides):
+    overrides = {k: lambda: v for k, v in overrides.items()}
+    getters = {
+        "build": get_build
+    }
+    return {k: g() for k, g, in (getters | overrides).items()}

--- a/vllm_hpu_extension/environment.py
+++ b/vllm_hpu_extension/environment.py
@@ -9,6 +9,19 @@ from pathlib import Path
 import re
 
 
+def get_hw():
+    import habana_frameworks.torch.utils.experimental as htexp
+    device_type = htexp._get_device_type()
+    match device_type:
+        case htexp.synDeviceType.synDeviceGaudi:
+            return "gaudi"
+        case htexp.synDeviceType.synDeviceGaudi2:
+            return "gaudi2"
+        case htexp.synDeviceType.synDeviceGaudi3:
+            return "gaudi3"
+    raise RuntimeError(f'Unknown device type: {device_type}')
+
+
 def get_build():
     import habana_frameworks.torch as htorch
     # This is ugly as hell, but it's the only reliable way of querying build number
@@ -25,6 +38,7 @@ def get_build():
 def get_environment(**overrides):
     overrides = {k: lambda: v for k, v in overrides.items()}
     getters = {
-        "build": get_build
+        "build": get_build,
+        "hw": get_hw,
     }
     return {k: g() for k, g, in (getters | overrides).items()}

--- a/vllm_hpu_extension/ops.py
+++ b/vllm_hpu_extension/ops.py
@@ -13,6 +13,7 @@ import torch.nn.functional as F
 import math
 
 from vllm.logger import init_logger
+from vllm_hpu_extension.capabilities import capabilities
 
 logger = init_logger(__name__)
 HPUFusedRMSNorm = None
@@ -109,7 +110,8 @@ class SoftmaxNormalization:
         return attn.sub_(grouped_max.unsqueeze(-1).unsqueeze(-1))
 
 
-normalize = SoftmaxNormalization(os.environ.get('VLLM_PA_SOFTMAX_IMPL', 'wsum_head_amax').split(','))
+DEFAULT_PA_SOFTMAX_IMPL = 'index_reduce' if 'index_reduce' in capabilities() else 'wsum_head_amax'
+normalize = SoftmaxNormalization(os.environ.get('VLLM_PA_SOFTMAX_IMPL', DEFAULT_PA_SOFTMAX_IMPL).split(','))
 
 
 def batch2block(tensor, block_mapping):

--- a/vllm_hpu_extension/test_capabilities.py
+++ b/vllm_hpu_extension/test_capabilities.py
@@ -1,0 +1,97 @@
+###############################################################################
+# Copyright (C) 2024 Habana Labs, Ltd. an Intel Company
+#
+# This source code is licensed under the Apache 2.0 license found in the
+# LICENSE file in the root directory of this source tree.
+###############################################################################
+
+import pytest
+
+from vllm_hpu_extension.capabilities import VersionRange, Capabilities
+
+
+def test_operators():
+    assert VersionRange("<1.19.0.100")(build="1.19.0.99")
+    assert not VersionRange("<1.19.0.100")(build="1.19.0.100")
+    assert not VersionRange("<1.19.0.100")(build="1.19.0.101")
+
+    assert VersionRange("<=1.19.0.100")(build="1.19.0.99")
+    assert VersionRange("<=1.19.0.100")(build="1.19.0.100")
+    assert not VersionRange("<=1.19.0.100")(build="1.19.0.101")
+
+    assert not VersionRange("==1.19.0.100")(build="1.19.0.99")
+    assert VersionRange("==1.19.0.100")(build="1.19.0.100")
+    assert not VersionRange("==1.19.0.100")(build="1.19.0.101")
+
+    assert not VersionRange(">1.19.0.100")(build="1.19.0.99")
+    assert not VersionRange(">1.19.0.100")(build="1.19.0.100")
+    assert VersionRange(">1.19.0.100")(build="1.19.0.101")
+
+    assert not VersionRange(">=1.19.0.100")(build="1.19.0.99")
+    assert VersionRange(">=1.19.0.100")(build="1.19.0.100")
+    assert VersionRange(">=1.19.0.100")(build="1.19.0.101")
+
+
+def test_two_ranges_same_release():
+    assert not VersionRange(">1.19.0.100,<1.19.0.200")(build="1.19.0.50")
+    assert VersionRange(">1.19.0.100,<1.19.0.200")(build="1.19.0.150")
+    assert not VersionRange(">1.19.0.100,<1.19.0.200")(build="1.19.0.250")
+
+
+def test_multiple_ranges_same_release():
+    ver_check = VersionRange(">=1.19.0.100,<1.19.0.200", ">=1.19.0.300,<1.19.0.400")
+    assert not ver_check(build="1.19.0.50")
+    assert ver_check(build="1.19.0.100")
+    assert ver_check(build="1.19.0.150")
+    assert not ver_check(build="1.19.0.200")
+    assert not ver_check(build="1.19.0.250")
+    assert ver_check(build="1.19.0.300")
+    assert ver_check(build="1.19.0.350")
+    assert not ver_check(build="1.19.0.400")
+    assert not ver_check(build="1.19.0.450")
+
+
+def test_other_releases():
+    ver_check = VersionRange(">=1.19.0.100")
+    assert ver_check(build="1.19.1.50")
+    assert ver_check(build="1.20.0.50")
+
+    ver_check = VersionRange("<1.19.0.100")
+    assert not ver_check(build="1.19.1.50")
+    assert not ver_check(build="1.20.0.50")
+
+    ver_check = VersionRange(">=1.19.0.100,<1.20.0")
+    assert ver_check(build="1.19.1.50")
+    assert not ver_check(build="1.20.0.50")
+
+
+@pytest.fixture
+def capabilities():
+    def feature(value):
+        def check(key):
+            assert key == "value"
+            return value
+        return check
+
+    env = {"key": "value"}
+    return Capabilities({
+        "foo": feature(True),
+        "bar": feature(False),
+        "qux": feature(True),
+    }, env)
+
+
+def test_capability_repr(capabilities):
+    capabilities_str = str(capabilities)
+    assert "-bar" in capabilities_str
+    assert "+foo" in capabilities_str
+    assert "+qux" in capabilities_str
+
+
+def test_capability_checks(capabilities):
+    assert "bar" not in capabilities
+    assert "foo" in capabilities
+    assert "qux" in capabilities
+    assert "foo,qux" in capabilities
+    assert "qux,foo" in capabilities
+    assert "foo,bar,qux" not in capabilities


### PR DESCRIPTION
This allows specifying which capabilities are available in current build. For example this can be used to enable certain algorithms when we know that current build supports them.