### PR TITLE
Backward compatibility of default normalization option

### DIFF
--- a/vllm_hpu_extension/ops.py
+++ b/vllm_hpu_extension/ops.py
@@ -110,7 +110,7 @@ class SoftmaxNormalization:
         return attn.sub_(grouped_max.unsqueeze(-1).unsqueeze(-1))
 
 
-DEFAULT_PA_SOFTMAX_IMPL = 'index_reduce'
+DEFAULT_PA_SOFTMAX_IMPL = "index_reduce" if "index_reduce" in capabilities() else "wsum_head_amax"
 normalize = SoftmaxNormalization(os.environ.get('VLLM_PA_SOFTMAX_IMPL', DEFAULT_PA_SOFTMAX_IMPL).split(','))
 
 


### PR DESCRIPTION
It may be possible that on older builds index_reduce op is not supported. In that case add option to automatically fallback  index_reduce to wsum_head_amax.