### PR TITLE
Pipeline PagedAttention

### DIFF
--- a/vllm_hpu_extension/ops.py
+++ b/vllm_hpu_extension/ops.py
@@ -120,7 +120,7 @@ def grouped_max(block_max, batch_size, block_groups):
     return group_max.unflatten(1, shape[1:4])
 
 
-DEFAULT_PA_SOFTMAX_IMPL = 'wsum_head_amax'
+DEFAULT_PA_SOFTMAX_IMPL = 'index_reduce'
 normalize = SoftmaxNormalization(os.environ.get('VLLM_PA_SOFTMAX_IMPL', DEFAULT_PA_SOFTMAX_IMPL).split(','))
 
 
@@ -138,19 +138,40 @@ def block2batch(tensor, block_mapping, matmul_op=torch.matmul):
 
 
 def block_softmax(batch_size, attn, block_mapping, block_scales, block_groups):
-    block_max = attn.amax(dim=-1, keepdim=True)
-    group_max = grouped_max(block_max, batch_size, block_groups)
-    block_adjustment = (group_max - block_max).exp().reciprocal()
-    attn = attn.sub(block_max)
-    attn = attn.exp()
-    sums = attn.sum(dim=-1, keepdim=True)
+    attn = normalize(batch_size=batch_size, attn=attn, block_mapping=block_mapping,
+                     block_scales=block_scales, block_groups=block_groups)
+    attn = torch.exp(attn)
+    sums = attn.sum(dim=-1).unsqueeze(-1)
     block_sum = sums
     sums = block2batch(sums, block_mapping)
     sums = batch2block(sums, block_mapping)
-    sums = sums.add(torch.finfo(sums.dtype).tiny)
+    sums.add_(torch.finfo(sums.dtype).tiny)
     sums = torch.maximum(block_sum, sums)
-    attn = attn.div(sums)
-    attn = attn.mul(block_adjustment)
+    attn.div_(sums)
+    return attn
+
+
+VLLM_USE_FFPA = os.environ.get('VLLM_USE_FFPA', 'false') == 'true'
+
+
+def attn_impl(use_ffpa, attn, value, matmul_av_op, batch_size, block_groups, block_mapping, block_scales):
+    if use_ffpa:
+        block_max = attn.amax(dim=-1, keepdim=True)
+        group_max = grouped_max(block_max, batch_size, block_groups)
+        block_adjustment = (group_max - block_max).exp()
+        attn = attn.sub(block_max)
+        attn = attn.exp()
+        sums = attn.sum(dim=-1, keepdim=True)
+        attn = matmul_av_op(attn, value)
+        attn = attn.div(block_adjustment)
+        sums = sums.div(block_adjustment)
+        prev_sums = sums
+        sums = batch2block(block2batch(sums, block_mapping), block_mapping)
+        sums = torch.maximum(sums, prev_sums)
+        attn = attn.div(sums)
+    else:
+        attn = block_softmax(batch_size, attn, block_mapping, block_scales, block_groups)
+        attn = matmul_av_op(attn, value)
     return attn
 
 
@@ -176,15 +197,26 @@ def flat_pa(query, key_cache, value_cache, block_list, block_mapping,
         key = key.transpose(2, 3)
 
     attn = matmul_qk_op(query, key) + block_bias
-    block_max = attn.amax(dim=-1, keepdim=True)
-    attn = attn.sub(block_max)
-    attn = attn.exp()
-    sums = attn.sum(dim=-1, keepdim=True)
-    attn = matmul_av_op(attn, value)
-    attn = attn.div(sums)
-    group_max = grouped_max(block_max, batch_size, block_groups)
-    block_adjustment = (group_max - block_max).exp().reciprocal()
-    attn = attn.mul(block_adjustment)
+    attn = attn_impl(VLLM_USE_FFPA, attn, value, matmul_av_op, batch_size, block_groups, block_mapping, block_scales)
+    #attn_true = attn_impl(True, attn, value, matmul_av_op, batch_size, block_groups, block_mapping, block_scales)
+    #attn_false = attn_impl(False, attn, value, matmul_av_op, batch_size, block_groups, block_mapping, block_scales)
+    #diff = (attn_true[0][0][0] - attn_false[0][0][0]).abs().max().item()#.tolist()
+    #print('diff:', diff)
+    #attn = attn_true
+    #attn = attn_true
+    #if VLLM_USE_FFPA:
+    #    block_max = attn.amax(dim=-1, keepdim=True)
+    #    attn = attn.sub(block_max)
+    #    attn = attn.exp()
+    #    sums = attn.sum(dim=-1, keepdim=True)
+    #    attn = matmul_av_op(attn, value)
+    #    attn = attn.div(sums)
+    #    group_max = grouped_max(block_max, batch_size, block_groups)
+    #    block_adjustment = (group_max - block_max).exp().reciprocal()
+    #    attn = attn.mul(block_adjustment)
+    #else:
+    #    attn = block_softmax(batch_size, attn, block_mapping, block_scales, block_groups)
+    #    attn = matmul_av_op(attn, value)
     attn = block2batch(attn, block_mapping, block2batch_matmul_op)
     attn = attn.squeeze(-2)
     if kv_heads != q_heads:

--- a/vllm_hpu_extension/ops.py
+++ b/vllm_hpu_extension/ops.py
@@ -158,7 +158,7 @@ def attn_impl(use_ffpa, attn, value, matmul_av_op, batch_size, block_groups, blo
         sums = torch.maximum(sums, prev_sums)
 
         attn = attn.mul_(block_adjustment.unsqueeze(-1).unsqueeze(-1))
-        attn = attn.div(sums.unsqueeze(-1).unsqueeze(-1))
+        attn = attn.div_(sums.unsqueeze(-1).unsqueeze(-1))
         attn = block2batch(attn, block_mapping)
     else:
         attn = normalize(batch_size=batch_size, attn=attn, block_mapping=block_mapping,

--- a/vllm_hpu_extension/ops.py
+++ b/vllm_hpu_extension/ops.py
@@ -93,10 +93,10 @@ class SoftmaxNormalization:
     @staticmethod
     def index_reduce(attn, batch_size, block_groups, **rest):
         """Normalize by max in block groups using index_reduce"""
-        #block_max = attn.amax(-1).squeeze(-1)
-        #grouped_max = torch.full([batch_size + 1, *attn.shape[1:-2]], -math.inf, dtype=attn.dtype, device=attn.device)
-        #grouped_max = grouped_max.index_reduce_(0, block_groups, block_max, 'amax')
-        #grouped_max = grouped_max.index_select(0, block_groups)
+        # block_max = attn.amax(-1).squeeze(-1)
+        # grouped_max = torch.full([batch_size + 1, *attn.shape[1:-2]], -math.inf, dtype=attn.dtype, device=attn.device)
+        # grouped_max = grouped_max.index_reduce_(0, block_groups, block_max, 'amax')
+        # grouped_max = grouped_max.index_select(0, block_groups)
         attn_shape = attn.shape
         attn = attn.flatten(1, 3)
         print(attn.shape)
@@ -117,7 +117,17 @@ class SoftmaxNormalization:
         return attn.sub_(grouped_max.unsqueeze(-1).unsqueeze(-1))
 
 
-DEFAULT_PA_SOFTMAX_IMPL = "index_reduce" if "index_reduce" in capabilities() else "wsum_head_amax"
+def renorm(block_max, batch_size, block_groups):
+    shape = block_max.shape
+    block_max = block_max.flatten(1, 3)
+    grouped_max = torch.full([batch_size + 1, *block_max.shape[1:]], -math.inf,
+                             dtype=block_max.dtype, device=block_max.device)
+    grouped_max = grouped_max.index_reduce_(0, block_groups, block_max, 'amax')
+    grouped_max = grouped_max.index_select(0, block_groups)
+    return grouped_max.reshape(shape)
+
+
+DEFAULT_PA_SOFTMAX_IMPL = 'wsum_head_amax'
 normalize = SoftmaxNormalization(os.environ.get('VLLM_PA_SOFTMAX_IMPL', DEFAULT_PA_SOFTMAX_IMPL).split(','))
 
 
@@ -135,16 +145,20 @@ def block2batch(tensor, block_mapping, matmul_op=torch.matmul):
 
 
 def block_softmax(batch_size, attn, block_mapping, block_scales, block_groups):
-    attn = normalize(batch_size=batch_size, attn=attn, block_mapping=block_mapping,
-                     block_scales=block_scales, block_groups=block_groups)
-    attn = torch.exp(attn)
-    sums = attn.sum(dim=-1).unsqueeze(-1)
-    block_sum = sums
-    sums = block2batch(sums, block_mapping)
-    sums = batch2block(sums, block_mapping)
-    sums.add_(torch.finfo(sums.dtype).tiny)
-    sums = torch.maximum(block_sum, sums)
-    attn.div_(sums)
+    block_max = attn.amax(dim=-1, keepdim=True)
+    print(attn.shape, block_max.shape)
+    attn.sub_(block_max)
+    # renorm(block_max, batch_size, block_groups)
+    # attn = normalize(batch_size=batch_size, attn=attn, block_mapping=block_mapping, block_scales=block_scales, block_groups=block_groups)
+    # attn = attn.exp_()
+    # sums = attn.sum(dim=-1, keepdim=True)
+    # renorm(attn, batch_size, block_groups)
+    # block_sum = sums
+    # sums = block2batch(sums, block_mapping)
+    # sums = batch2block(sums, block_mapping)
+    # sums.add_(torch.finfo(sums.dtype).tiny)
+    # sums = torch.maximum(block_sum, sums)
+    # attn.div_(sums)
     return attn
 
 

--- a/vllm_hpu_extension/ops.py
+++ b/vllm_hpu_extension/ops.py
@@ -151,7 +151,7 @@ def block_softmax(batch_size, attn, block_mapping, block_scales, block_groups):
     return attn
 
 
-VLLM_USE_FFPA = os.environ.get('VLLM_USE_FFPA', 'false') == 'true'
+VLLM_USE_FFPA = os.environ.get('VLLM_USE_FFPA', 'false')
 
 
 def attn_impl(use_ffpa, attn, value, matmul_av_op, batch_size, block_groups, block_mapping, block_scales):
@@ -199,27 +199,18 @@ def flat_pa(query, key_cache, value_cache, block_list, block_mapping,
         key = key.transpose(2, 3)
 
     attn = matmul_qk_op(query, key) + block_bias
-    #attn = attn_impl(VLLM_USE_FFPA, attn, value, matmul_av_op, batch_size, block_groups, block_mapping, block_scales)
-    attn_true = attn_impl(True, attn, value, matmul_av_op, batch_size, block_groups, block_mapping, block_scales)
-    attn_false = attn_impl(False, attn, value, matmul_av_op, batch_size, block_groups, block_mapping, block_scales)
-    #diff = (attn_true[1][0][0] - attn_false[1][0][0]).abs().max().item()#.tolist()
-    diff = (attn_true - attn_false).abs().max().item()#.tolist()
-    print('diff:', diff)
-    #attn = attn_true
-    attn = attn_false
-    #if VLLM_USE_FFPA:
-    #    block_max = attn.amax(dim=-1, keepdim=True)
-    #    attn = attn.sub(block_max)
-    #    attn = attn.exp()
-    #    sums = attn.sum(dim=-1, keepdim=True)
-    #    attn = matmul_av_op(attn, value)
-    #    attn = attn.div(sums)
-    #    group_max = grouped_max(block_max, batch_size, block_groups)
-    #    block_adjustment = (group_max - block_max).exp().reciprocal()
-    #    attn = attn.mul(block_adjustment)
-    #else:
-    #    attn = block_softmax(batch_size, attn, block_mapping, block_scales, block_groups)
-    #    attn = matmul_av_op(attn, value)
+    if VLLM_USE_FFPA == 'diff':
+        attn_true = attn_impl(True, attn, value, matmul_av_op, batch_size, block_groups, block_mapping, block_scales)
+        attn_false = attn_impl(False, attn, value, matmul_av_op, batch_size, block_groups, block_mapping, block_scales)
+        diff = (attn_true - attn_false).abs().max().item()#.tolist()
+        print('diff:', diff)
+        attn = attn_false
+    elif VLLM_USE_FFPA == 'true':
+        attn = attn_impl(True, attn, value, matmul_av_op, batch_size, block_groups, block_mapping, block_scales)
+    elif VLLM_USE_FFPA == 'false':
+        attn = attn_impl(False, attn, value, matmul_av_op, batch_size, block_groups, block_mapping, block_scales)
+    else:
+        assert False
     attn = attn.squeeze(-2)
     if kv_heads != q_heads:
         attn = attn.flatten(1, 2)

--- a/vllm_hpu_extension/ops.py
+++ b/vllm_hpu_extension/ops.py
@@ -159,11 +159,11 @@ def attn_impl(use_ffpa, attn, value, matmul_av_op, batch_size, block_groups, blo
         block_max = attn.amax(dim=-1, keepdim=True)
         attn = attn.sub(block_max)
         attn = attn.exp()
-        sums = attn.sum(dim=-1, keepdim=True)
+        sums = attn.sum(dim=-1).squeeze(-1)
         attn = matmul_av_op(attn, value)
 
         group_max = grouped_max(block_max, batch_size, block_groups)
-        block_adjustment = (group_max - block_max).exp().reciprocal()
+        block_adjustment = (group_max.squeeze(-1).squeeze(-1) - block_max.squeeze(-1).squeeze(-1)).exp().reciprocal()
 
         sums = sums.mul_(block_adjustment)
         prev_sums = sums
@@ -171,8 +171,8 @@ def attn_impl(use_ffpa, attn, value, matmul_av_op, batch_size, block_groups, blo
         sums = batch2block(sums, block_mapping)
         sums = torch.maximum(sums, prev_sums)
 
-        attn = attn.mul_(block_adjustment)
-        attn = attn.div(sums)
+        attn = attn.mul_(block_adjustment.unsqueeze(-1).unsqueeze(-1))
+        attn = attn.div(sums.unsqueeze(-1).unsqueeze(-1))
         attn = block2batch(attn, block_mapping)
     else:
         attn = block_softmax(batch_size, attn, block_mapping, block_scales, block_groups)

--- a/vllm_hpu_extension/ops.py
+++ b/vllm_hpu_extension/ops.py
@@ -93,11 +93,18 @@ class SoftmaxNormalization:
     @staticmethod
     def index_reduce(attn, batch_size, block_groups, **rest):
         """Normalize by max in block groups using index_reduce"""
-        block_max = attn.amax(-1).squeeze(-1)
-        grouped_max = torch.full([batch_size + 1, *attn.shape[1:-2]], -math.inf, dtype=attn.dtype, device=attn.device)
-        grouped_max = grouped_max.index_reduce_(0, block_groups, block_max, 'amax')
+        #block_max = attn.amax(-1).squeeze(-1)
+        #grouped_max = torch.full([batch_size + 1, *attn.shape[1:-2]], -math.inf, dtype=attn.dtype, device=attn.device)
+        #grouped_max = grouped_max.index_reduce_(0, block_groups, block_max, 'amax')
+        #grouped_max = grouped_max.index_select(0, block_groups)
+        attn_shape = attn.shape
+        attn = attn.flatten(1, 3)
+        print(attn.shape)
+        grouped_max = torch.full([batch_size + 1, *attn.shape[1:]], -math.inf, dtype=attn.dtype, device=attn.device)
+        grouped_max = grouped_max.index_reduce_(0, block_groups, attn, 'amax')
         grouped_max = grouped_max.index_select(0, block_groups)
-        return attn.sub_(grouped_max.unsqueeze(-1).unsqueeze(-1))
+        attn.sub_(grouped_max)
+        return attn.reshape(attn_shape)
 
     @staticmethod
     def scatter_reduce(attn, batch_size, block_groups, **rest):
@@ -162,8 +169,17 @@ def flat_pa(query, key_cache, value_cache, block_list, block_mapping,
     else:
         key = key.transpose(2, 3)
 
-    attn = matmul_qk_op(query, key) + block_bias
-    attn = block_softmax(batch_size, attn, block_mapping, block_scales, block_groups)
+    print(query.shape, key.shape, block_bias.shape)
+    if os.environ.get('VLLM_PA_SPLIT_HEADS', 'false') == 'true':
+        query_slices = query.split(1, dim=2)
+    else:
+        query_slices = [query]
+    attn_slices = []
+    for q in query_slices:
+        attn = matmul_qk_op(q, key) + block_bias
+        attn = block_softmax(batch_size, attn, block_mapping, block_scales, block_groups)
+        attn_slices.append(attn)
+    attn = torch.cat(attn_slices, dim=2)
     attn = matmul_av_op(attn, value)
     attn = block2batch(attn, block_mapping, block2batch_matmul_op)
     attn = attn.squeeze(-2)

--- a/vllm_hpu_extension/ops.py
+++ b/vllm_hpu_extension/ops.py
@@ -169,9 +169,11 @@ def attn_impl(use_ffpa, attn, value, matmul_av_op, batch_size, block_groups, blo
         sums = batch2block(block2batch(sums, block_mapping), block_mapping)
         sums = torch.maximum(sums, prev_sums)
         attn = attn.div(sums)
+        attn = block2batch(attn, block_mapping)
     else:
         attn = block_softmax(batch_size, attn, block_mapping, block_scales, block_groups)
         attn = matmul_av_op(attn, value)
+        attn = block2batch(attn, block_mapping)
     return attn
 
 
@@ -197,13 +199,14 @@ def flat_pa(query, key_cache, value_cache, block_list, block_mapping,
         key = key.transpose(2, 3)
 
     attn = matmul_qk_op(query, key) + block_bias
-    attn = attn_impl(VLLM_USE_FFPA, attn, value, matmul_av_op, batch_size, block_groups, block_mapping, block_scales)
-    #attn_true = attn_impl(True, attn, value, matmul_av_op, batch_size, block_groups, block_mapping, block_scales)
-    #attn_false = attn_impl(False, attn, value, matmul_av_op, batch_size, block_groups, block_mapping, block_scales)
-    #diff = (attn_true[0][0][0] - attn_false[0][0][0]).abs().max().item()#.tolist()
-    #print('diff:', diff)
+    #attn = attn_impl(VLLM_USE_FFPA, attn, value, matmul_av_op, batch_size, block_groups, block_mapping, block_scales)
+    attn_true = attn_impl(True, attn, value, matmul_av_op, batch_size, block_groups, block_mapping, block_scales)
+    attn_false = attn_impl(False, attn, value, matmul_av_op, batch_size, block_groups, block_mapping, block_scales)
+    #diff = (attn_true[1][0][0] - attn_false[1][0][0]).abs().max().item()#.tolist()
+    diff = (attn_true - attn_false).abs().max().item()#.tolist()
+    print('diff:', diff)
     #attn = attn_true
-    #attn = attn_true
+    attn = attn_false
     #if VLLM_USE_FFPA:
     #    block_max = attn.amax(dim=-1, keepdim=True)
     #    attn = attn.sub(block_max)
@@ -217,7 +220,6 @@ def flat_pa(query, key_cache, value_cache, block_list, block_mapping,
     #else:
     #    attn = block_softmax(batch_size, attn, block_mapping, block_scales, block_groups)
     #    attn = matmul_av_op(attn, value)
-    attn = block2batch(attn, block_mapping, block2batch_matmul_op)
     attn = attn.squeeze(-2)
     if kv_heads != q_heads:
         attn = attn.flatten(1, 2)


### PR DESCRIPTION
This PR implements Pipelined PagedAttention, that applies the concepts of FlashAttention into PagedAttention.
The concept is to perform matmul_av (A @ V), before calculating grouped maximum (max value shared between blocks for single sequence) and grouped sum (sum of exponents that belongs to the same sequence).
Thanks to that, we can perform softmax calculation in parallel to A @ V calculation. 
In the end, just like in FlashAttention we need to apply softmax rescaling to correct denominator. 

This PR also clean-ups the code so we have only one way of performing normalization for exponent.