### PR TITLE
remove expert_max hard code

### DIFF
--- a/vllm_hpu_extension/ops.py
+++ b/vllm_hpu_extension/ops.py
@@ -434,7 +434,7 @@ class DynamicFusedMOE(torch.nn.Module):
             permuted_weights=True,
             activation="silu",
             experts_min=0,
-            experts_max=7
+            experts_max=self.num_total_experts
         )
 
         return final_hidden_states.view(-1, hidden_states.shape[1])


### PR DESCRIPTION
so that the other MoE model beyond 7 experts can be exectued in dynamic mode

verified by deepseek v2 Lite