### PR TITLE
vLLM-Ext: Full enabling of ALiBi

### DIFF
--- a/vllm_hpu_extension/flags.py
+++ b/vllm_hpu_extension/flags.py
@@ -150,6 +150,8 @@ def enabled_flags():
         "gaudi2": Hardware("gaudi2"),
         "gaudi3": Hardware("gaudi3"),
         "cpu": Hardware("cpu"),
+        "contiguous_pa": EnvFlag("VLLM_CONTIGUOUS_PA", 'true'),
+        "fp32_alibi_biases": EnvFlag("VLLM_ALIBI_USE_FLOAT32_BIASES", '1'),
         "fp32_softmax": EnvFlag("VLLM_FP32_SOFTMAX", ModelType('qwen2')),
         "fsdpa": (Not(Hardware("cpu"))
                   & Kernel(fsdpa)

--- a/vllm_hpu_extension/ops.py
+++ b/vllm_hpu_extension/ops.py
@@ -94,10 +94,24 @@ def pipelined_pa(attn, value, block_groups, block_mapping, block_scales, batch_s
     return attn
 
 
-def flat_pa(query, key_cache, value_cache, block_list, block_mapping,
-            block_bias, block_scales, block_groups, scale, matmul_qk_op,
-            matmul_av_op, batch2block_matmul_op, block2batch_matmul_op,
-            keys_fetch_func, values_fetch_func):
+def flat_pa(
+    query,
+    key_cache,
+    value_cache,
+    block_list,
+    block_mapping,
+    block_bias,
+    block_scales,
+    block_groups,
+    scale,
+    position_bias,
+    matmul_qk_op,
+    matmul_av_op,
+    batch2block_matmul_op,
+    block2batch_matmul_op,
+    keys_fetch_func,
+    values_fetch_func,
+):
     batch_size = query.size(0)
     q_heads = query.size(1)
     kv_heads = key_cache.size(2)
@@ -107,24 +121,38 @@ def flat_pa(query, key_cache, value_cache, block_list, block_mapping,
     value = values_fetch_func(value_cache, block_list).transpose(1, 2)
     block_bias = block_bias.view(key.size(0), 1, 1, -1)
     if kv_heads != q_heads:
-        block_bias = block_bias.unsqueeze(1)
         query = query.unflatten(1, (kv_heads, -1))
         key = key.unflatten(1, (kv_heads, 1))
         value = value.unflatten(1, (kv_heads, 1))
-        key = key.transpose(3, 4)
-    else:
-        key = key.transpose(2, 3)
+        if position_bias is not None:
+            position_bias = position_bias.unflatten(1, (kv_heads, -1))
+        if block_bias is not None:
+            block_bias = block_bias.unsqueeze(2)
+    key = key.transpose(-2, -1)
 
     attn = matmul_qk_op(query, key)
     if 'fp32_softmax' in enabled_flags():
         attn = attn.float()
         htcore.mark_step()
-    attn = attn + block_bias
+        if position_bias is not None:
+            position_bias = position_bias.float()
+    if position_bias is not None:
+        if attn.dtype != position_bias.dtype:
+            attn = attn.to(dtype=position_bias.dtype)
+        attn.add_(position_bias.unsqueeze(-2))
+    if block_bias is not None:
+        if attn.dtype != block_bias.dtype:
+            block_bias = block_bias.to(dtype=attn.dtype)
+        attn.add_(block_bias)
+    if 'fp32_softmax' in enabled_flags():
+        attn = attn.to(query.dtype)
+
     attn = pipelined_pa(attn, value, block_groups, block_mapping, block_scales=block_scales,
                         batch_size=batch_size, matmul_av_op=matmul_av_op,
                         batch2block_matmul_op=batch2block_matmul_op, block2batch_matmul_op=block2batch_matmul_op)
     attn = block2batch(attn, block_mapping, block2batch_matmul_op)
     attn = attn.squeeze(-2)
+
     if kv_heads != q_heads:
         attn = attn.flatten(1, 2)
     return attn
@@ -135,6 +163,7 @@ def prompt_attention(
     key: torch.Tensor,
     value: torch.Tensor,
     attn_bias: Optional[torch.Tensor] = None,
+    position_bias: Optional[torch.Tensor] = None,
     p: float = 0.0,
     scale: Optional[float] = None,
     matmul_qk_op=torch.matmul,
@@ -153,20 +182,34 @@ def prompt_attention(
             query = query.unflatten(1, (kv_heads, -1))
             key = key.unflatten(1, (kv_heads, 1))
             value = value.unflatten(1, (kv_heads, 1))
+            if position_bias is not None:
+                position_bias = position_bias.unflatten(1, (kv_heads, -1))
             if attn_bias is not None:
                 attn_bias = attn_bias.unsqueeze(2)
-        attn_weights = matmul_qk_op(query * scale, key.transpose(-1, -2))
+        key = key.transpose(-2, -1)
+        attn_weights = matmul_qk_op(query * scale, key)
         if 'fp32_softmax' in enabled_flags():
             attn_weights = attn_weights.float()
             htcore.mark_step()
+            if position_bias is not None:
+                position_bias = position_bias.float()
+
+        if position_bias is not None:
+            if attn_weights.dtype != position_bias.dtype:
+                attn_weights = attn_weights.to(dtype=position_bias.dtype)
+                htcore.mark_step()
+            attn_weights.add_(position_bias)
         if attn_bias is not None:
-            attn_weights = attn_weights.add(attn_bias)
+            if attn_weights.dtype != attn_bias.dtype:
+                attn_bias = attn_bias.to(dtype=attn_weights.dtype)
+            attn_weights.add_(attn_bias)
         if 'fp32_softmax' in enabled_flags():
             attn_weights = torch.softmax(attn_weights, dim=-1)
         else:
             attn_weights = softmax_op(attn_weights, dim=-1)
         attn_weights = attn_weights.to(query.dtype)
         attn_weights = matmul_av_op(attn_weights, value)
+
         if query_heads != kv_heads:
             attn_weights = attn_weights.flatten(1, 2)
     else:


### PR DESCRIPTION
Changes:
- Added back alibi biases to decode stage.
- Optimized ALiBI memory usage.
  - Added environment variable "VLLM_PROMPT_ALIBI_MAX_SEQ_LEN" to allow large models to run with restricted prompt lengths.
  - Prompt biases instantiated once in __init__ rather than each forward.
  - Prompt and decode biases are shared across encoder/decoder layers.
- Added environment variable "VLLM_ALIBI_USE_FLOAT32_BIASES" to resolve accuracy issue on long sequences.
- Updated jais, mpt, falcon, baichuan, and bloom to work with ALiBI.
  - Due to bloom's 176B parameter size I was unable to test this model. Its changes are the simplest though.
- Works in lazy and eager mode.
- ALiBI is restricted to "VLLM_PROMPT_USE_FUSEDSDPA=false", and "VLLM_CONTIGUOUS_PA=true".
- Add position offsets to improve quality on BS > 1 with sequences of varying length.
- BS > 1 may have accuracy issues if on FW < 1.19.0. This is due to limitation in softmax. Resolved on FW >= 1.19.0.
- NTT patch for GQA