### PR TITLE
Removed previous (not-pipelined) pa implementation

### DIFF
--- a/vllm_hpu_extension/capabilities.py
+++ b/vllm_hpu_extension/capabilities.py
@@ -71,7 +71,6 @@ class Capabilities:
 @cache
 def capabilities():
     supported_features = {
-        "index_reduce": VersionRange(">=1.19.0.272"),
         "gaudi": Hardware("gaudi"),
         "gaudi2": Hardware("gaudi2"),
         "gaudi3": Hardware("gaudi3"),

--- a/vllm_hpu_extension/ops.py
+++ b/vllm_hpu_extension/ops.py
@@ -76,35 +76,6 @@ def pipelined_pa(attn, value, block_groups, block_mapping, block_scales, batch_s
     return attn
 
 
-def pa(attn, value, block_groups, block_mapping, block_scales, batch_size,
-       matmul_av_op, batch2block_matmul_op, block2batch_matmul_op):
-    attn_max = attn.amax(-1)
-    missing_dims = attn_max.dim() - block_scales.dim()
-    block_sum_attn = attn_max.mul(block_scales.reshape(-1, *[1 for _ in range(missing_dims)]))
-    block_sum_attn = block2batch(block_sum_attn, block_mapping, block2batch_matmul_op)
-    block_sum_attn = batch2block(block_sum_attn, block_mapping, batch2block_matmul_op)
-    attn.sub_(block_sum_attn.unsqueeze(-1))
-    attn_max.sub_(block_sum_attn)
-    attn_max = attn_max.amax(0, keepdim=True)
-    attn.sub_(attn_max.unsqueeze(-1))
-    attn = attn.exp()
-    sums = attn.sum(dim=-1).unsqueeze(-1)
-    block_sum = sums
-    # Sum block's sums that belongs to the same sequeneces
-    sums = block2batch(sums, block_mapping, block2batch_matmul_op)
-    group_sums = batch2block(sums, block_mapping, batch2block_matmul_op)
-    group_sums.add_(torch.finfo(group_sums.dtype).tiny)
-    group_sums = torch.maximum(block_sum, group_sums)
-    attn.div_(group_sums)
-    attn = matmul_av_op(attn, value)
-    return attn
-
-
-pipelined_pa_enabled = 'True' if "index_reduce" in capabilities() else 'False'
-pipelined_pa_enabled = os.environ.get('VLLM_PIPELINED_PA', pipelined_pa_enabled).lower() == 'true'
-pa_impl = pipelined_pa if pipelined_pa_enabled else pa
-
-
 def flat_pa(query, key_cache, value_cache, block_list, block_mapping,
             block_bias, block_scales, block_groups, scale, matmul_qk_op,
             matmul_av_op, batch2block_matmul_op, block2batch_matmul_op,
@@ -127,9 +98,9 @@ def flat_pa(query, key_cache, value_cache, block_list, block_mapping,
         key = key.transpose(2, 3)
 
     attn = matmul_qk_op(query, key) + block_bias
-    attn = pa_impl(attn, value, block_groups, block_mapping, block_scales=block_scales,
-                   batch_size=batch_size, matmul_av_op=matmul_av_op,
-                   batch2block_matmul_op=batch2block_matmul_op, block2batch_matmul_op=block2batch_matmul_op)
+    attn = pipelined_pa(attn, value, block_groups, block_mapping, block_scales=block_scales,
+                        batch_size=batch_size, matmul_av_op=matmul_av_op,
+                        batch2block_matmul_op=batch2block_matmul_op, block2batch_matmul_op=block2batch_matmul_op)
     attn = block2batch(attn, block_mapping, block2batch_matmul_op)
     attn = attn.squeeze(-2)
     if kv_heads != q_heads:


### PR DESCRIPTION
index_reduce is available in latest released version. No need to have a separate pa implementation as pipelined pa outperforms previous implementation.