### PR TITLE
Fix high-level profiler filename

### DIFF
--- a/vllm_hpu_extension/profiler.py
+++ b/vllm_hpu_extension/profiler.py
@@ -66,7 +66,7 @@ class HabanaHighLevelProfiler:
                 else f"vllm-instance-{str(uuid.uuid4().hex)}"
             msg = f'Profiler enabled for: {self.vllm_instance_id}'
             logger.info(msg)
-            self.filename = f'server_events_{vllm_instance_id}.json'
+            self.filename = f'server_events_{self.vllm_instance_id}.json'
             # initialize the trace file (JSON Array Format)
             with open(self.filename, 'w') as outfile:
                 outfile.write('[')


### PR DESCRIPTION
Small bug was introduced in https://github.com/HabanaAI/vllm-hpu-extension/pull/52/files 
line 69:

if `vllm_instance_id` is None then `self.filename = server_events_None.json`

Kudos to @tianmu-li !