### PR TITLE
Enables multinode calibration flow through calibrate_model.sh

### DIFF
--- a/calibration/README.md
+++ b/calibration/README.md
@@ -86,6 +86,7 @@ Running the above command should create the calibration measurement files in the
   
   1. Facing error "nic/port is down". <br>
   This happens when the Gaudi card nic ports are down. On every node check the port status as below.<br>
+  Note : Follwing commands should be run on the host and NOT inside the container. <br>
      
 ```bash
 cd /opt/habanalabs/qual/gaudi2/bin 

--- a/calibration/README.md
+++ b/calibration/README.md
@@ -60,6 +60,9 @@ ray start --head --port=6379
 
 # Add worker nodes to the Ray cluster
 ray start --address='<ip-of-ray-head-node>:6379'
+
+# Check if the cluster has required number of HPU's
+ray status
 ```
 
 #### Step 3: Run model calibration script

--- a/calibration/README.md
+++ b/calibration/README.md
@@ -63,5 +63,5 @@ ray start --address='<ip-of-ray-head-node>:6379'
 
 Step 3: Run calibrate_model.sh script
 ```
-
+./calibrate_model.sh -m meta-llama/Llama-3.1-405B-Instruct -d open_orca_gpt4_tokenized_llama.calibration_1000.pkl -o fp8_output -l 10 -t 16 -b 1
 ```

--- a/calibration/README.md
+++ b/calibration/README.md
@@ -86,7 +86,7 @@ Running the above command should create the calibration measurement files in the
   
   1. Facing error "nic/port is down". <br>
   This happens when the Gaudi card nic ports are down. On every node check the port status as below.<br>
-  Note : Follwing commands should be run on the host and NOT inside the container. <br>
+  Note : Following commands should be run on the host and NOT inside the container. <br>
      
 ```bash
 cd /opt/habanalabs/qual/gaudi2/bin 

--- a/calibration/README.md
+++ b/calibration/README.md
@@ -36,7 +36,7 @@ An inference with FP8 precision models using vLLM has been described in [README_
 > [!WARNING] 
 > !! Mutli-node calibration is an experimental feature and could have stability issues.
 
-Following section details the procedure for calibrating models that do not fit into a single Gaudi node. For illustration we have used the Llama 3.1 405B model running in Tensor Parallelism(TP)-16 mode spanning two Guadi2 nodes.<br>
+Following section details the procedure for calibrating models that do not fit into a single Gaudi node. For illustration we have used the Llama 3.1 405B model running in Tensor Parallelism(TP)-16 mode spanning two Gaudi2 nodes.<br>
 Note : Following steps are to be executed within a [Gaudi Pytorch container](https://docs.habana.ai/en/latest/Installation_Guide/Additional_Installation/Docker_Installation.html#use-intel-gaudi-containers)
 
 #### Step 1: Pre-requisites
@@ -71,7 +71,7 @@ ray status
 
 #### Step 3: Run model calibration script
 ```bash
-./calibrate_model.sh -m meta-llama/Llama-3.1-405B-Instruct -d <path-to-dataset>/open_orca_gpt4_tokenized_llama.calibration_1000.pkl -o <path-to-calibration-output>/fp8_output -l 10 -t 16 -b 1
+./calibrate_model.sh -m meta-llama/Llama-3.1-405B-Instruct -d <path-to-dataset>/open_orca_gpt4_tokenized_llama.calibration_1000.pkl -o <path-to-calibration-output>/fp8_output -l 4096 -t 16 -b 128
 ```
 Running the above command should create the calibration measurement files in the specified output directory with model specific sub-directories.<br>
 <details><summary>Arguments used</summary>

--- a/calibration/README.md
+++ b/calibration/README.md
@@ -30,3 +30,24 @@ Here are some examples of how to use the script:
 # Run inference with FP8 models
 
 An inference with FP8 precision models using vLLM has been described in [README_GAUDI](https://github.com/HabanaAI/vllm-fork/blob/habana_main/README_GAUDI.md#quantization-fp8-inference-and-model-calibration-process) file.
+
+# Multi-node FP8 Calibration
+
+Following section details the procedure for calibrating models that do not fit into a single Gaudi node. For illustration we have used the Llama 3.1 405B model running in TP-16 mode spanning two Guadi2 nodes.
+
+Step 1: Start a Ray cluster to accomodate the required TP size. 
+```
+# Export the required env variables seperately on all nodes.
+export PT_HPU_ENABLE_LAZY_COLLECTIVES=true
+export EXPERIMENTAL_WEIGHT_SHARING="0"
+export VLLM_SKIP_WARMUP="true"
+export GLOO_SOCKET_IFNAME=eth0
+export QUANT_CONFIG="<path-to-config>/quant_config_buffer.json"
+
+# Start Ray on head node
+ray start --head --port=6379
+
+# Add worker nodes to the Ray cluster
+ray start --address='<ip-of-ray-head-node>:6379'
+```
+

--- a/calibration/README.md
+++ b/calibration/README.md
@@ -101,7 +101,7 @@ cd /opt/habanalabs/qual/gaudi2/bin
 #### Step 4: (optional) Measurement unification <p>
 This is an optional step and is used to reduce the target tensor parallelism level by unifying the measurement scales.<br> For eg: You can perform FP8 calibration on the Llama 3.1 405B model on 2x Gaudi2 nodes with Tensor Parallelism = 16 and then use the unification script to reduce the TP to 8. Refer sample command below
 ```bash
-python step-5-unify_measurements.py -g "0,1--2,3--4,5--6,7--8,9--10,11--12,13--14,15"  -m <path-to-calibration-output>/fp8_output/llama-3.1-405b-instruct/g2/ -o ./unification_files_8x
+python step-5-unify_measurements.py -g "0,8--1,9--2,10--3,11--4,12--5,13--6,14--7,15"  -m <path-to-calibration-output>/fp8_output/llama-3.1-405b-instruct/g2/ -o ./unification_files_8x
 ```
 <details><summary>Arguments used</summary>
 -g - card grouping to use during unification, card indices separated by commas and groups separated by double dash<br>

--- a/calibration/README.md
+++ b/calibration/README.md
@@ -39,14 +39,14 @@ Following section details the procedure for calibrating models that do not fit i
   - Install latest [vllm-fork](https://github.com/HabanaAI/vllm-fork/blob/habana_main/README_GAUDI.md#build-and-install-vllm)
   - Ensure that all nodes in the multi-node setup are connected to an NFS mount (Network File System).
   - Create workspace directory on NFS, clone the calibration scripts repo and create an empty file 'quant_config_buffer.json'.
-    ```
+    ```bash
     mkdir <nfs-mount-path>/my_workspace && cd <nfs-mount-path>/my_workspace
     git clone https://github.com/HabanaAI/vllm-hpu-extension.git && cd vllm-hpu-extension/calibration
     touch quant_config_buffer.json 
     ```
 
 #### Step 2: Start a Ray cluster to accommodate the required TP size. 
-```
+```bash
 # Export the required env variables separately on all nodes.
 export PT_HPU_ENABLE_LAZY_COLLECTIVES=true
 export EXPERIMENTAL_WEIGHT_SHARING="0"
@@ -63,7 +63,7 @@ ray start --address='<ip-of-ray-head-node>:6379'
 ```
 
 #### Step 3: Run model calibration script
-```
+```bash
 ./calibrate_model.sh -m meta-llama/Llama-3.1-405B-Instruct -d <path-to-dataset>/open_orca_gpt4_tokenized_llama.calibration_1000.pkl -o <path-to-calibration-output>/fp8_output -l 10 -t 16 -b 1
 ```
 Running the above command should create the calibration measurement files in the specified output directory with model specific sub-directories.<br>
@@ -75,20 +75,35 @@ Running the above command should create the calibration measurement files in the
 -t tensor parallelism<br> 
 -b batch_size for calibration<br> </details>
 
+<details><summary>Common issues</summary> 
+  
+  1. Facing error "nic/port is down". <br>
+  This happens when the Gaudi card nic ports are down. On every node check the port status as below.<br>
+     
+```bash
+cd /opt/habanalabs/qual/gaudi2/bin 
+./manage_network_ifs.sh --status 
+# All the ports should be in 'up' state. Try flipping the state
+./manage_network_ifs.sh --down 
+./manage_network_ifs.sh --up 
+```  
+  </details>
+
+
 #### Step 4: (optional) Measurement unification <p>
 This is an optional step and is used to reduce the target tensor parallelism level by unifying the measurement scales.<br> For eg: You can perform FP8 calibration on the Llama 3.1 405B model on 2x Gaudi2 nodes with Tensor Parallelism = 16 and then use the unification script to reduce the TP to 8. Refer sample command below
-```
+```bash
 python step-5-unify_measurements.py -g "0,1--2,3--4,5--6,7--8,9--10,11--12,13--14,15"  -m <path-to-calibration-output>/fp8_output/llama-3.1-405b-instruct/g2/ -o ./unification_files_8x
 ```
 <details><summary>Arguments used</summary>
--g - card grouping to use during unification <br>
+-g - card grouping to use during unification, card indices separated by commas and groups separated by double dash<br>
 -m - calibration output path which has the measurement files <br>
 -o - output directory where unification output gets written<br></details>
 
 #### Step 5: Serving the FP8 quantized model <p>
-```
+```bash
 export QUANT_CONFIG='<path-to-calibration-output>/fp8_output/llama-3.1-405b-instruct/maxabs_quant_g2.json'
-vllm serve meta-llama/Llama-3.1-405B-Instruct --quantization inc --kv-cache-dtype fp8_inc --weights-load-device cpu --tensor_paralel_size 8
+vllm serve meta-llama/Llama-3.1-405B-Instruct --quantization inc --kv-cache-dtype fp8_inc --weights-load-device cpu --tensor-parallel-size 8
 ```
 Note : For serving the output after unification, edit the QUANT_CONFIG file to point the 'dump_stats_path' value to the unification output directory
 

--- a/calibration/README.md
+++ b/calibration/README.md
@@ -31,11 +31,21 @@ Here are some examples of how to use the script:
 
 An inference with FP8 precision models using vLLM has been described in [README_GAUDI](https://github.com/HabanaAI/vllm-fork/blob/habana_main/README_GAUDI.md#quantization-fp8-inference-and-model-calibration-process) file.
 
-# Multi-node FP8 Calibration
+# (experimental) Multi-node FP8 Calibration 
 
 Following section details the procedure for calibrating models that do not fit into a single Gaudi node. For illustration we have used the Llama 3.1 405B model running in TP-16 mode spanning two Guadi2 nodes.
 
-Step 1: Start a Ray cluster to accomodate the required TP size. 
+Step 1: Pre-requisites
+  - Install latest [vllm-fork](https://github.com/HabanaAI/vllm-fork/blob/habana_main/README_GAUDI.md#build-and-install-vllm)
+  - Ensure that all nodes in the multi-node setup are connected to an NFS mount (Network File System).
+  - Create workspace directory on NFS, clone the calibration scripts repo and create an empty file 'quant_config_buffer.json'.
+    ```
+    mkdir <nfs-mount-path>/my_workspace && cd <nfs-mount-path>/my_workspace
+    git clone https://github.com/HabanaAI/vllm-hpu-extension.git && cd vllm-hpu-extension/calibration
+    touch quant_config_buffer.json 
+    ```
+
+Step 2: Start a Ray cluster to accomodate the required TP size. 
 ```
 # Export the required env variables seperately on all nodes.
 export PT_HPU_ENABLE_LAZY_COLLECTIVES=true
@@ -51,3 +61,7 @@ ray start --head --port=6379
 ray start --address='<ip-of-ray-head-node>:6379'
 ```
 
+Step 3: Run calibrate_model.sh script
+```
+
+```

--- a/calibration/README.md
+++ b/calibration/README.md
@@ -34,7 +34,7 @@ An inference with FP8 precision models using vLLM has been described in [README_
 # Multi-node FP8 Calibration 
 
 > [!WARNING] 
-> !! Mutli-node calibration is an experimental feature and could have stability issues.
+> Multi-node calibration is an experimental feature and could have stability issues.
 
 Following section details the procedure for calibrating models that do not fit into a single Gaudi node. For illustration we have used the Llama 3.1 405B model running in Tensor Parallelism(TP)-16 mode spanning two Gaudi2 nodes.<br>
 Note : Following steps are to be executed within a [Gaudi Pytorch container](https://docs.habana.ai/en/latest/Installation_Guide/Additional_Installation/Docker_Installation.html#use-intel-gaudi-containers)

--- a/calibration/README.md
+++ b/calibration/README.md
@@ -31,9 +31,13 @@ Here are some examples of how to use the script:
 
 An inference with FP8 precision models using vLLM has been described in [README_GAUDI](https://github.com/HabanaAI/vllm-fork/blob/habana_main/README_GAUDI.md#quantization-fp8-inference-and-model-calibration-process) file.
 
-# (experimental) Multi-node FP8 Calibration 
+# Multi-node FP8 Calibration 
 
-Following section details the procedure for calibrating models that do not fit into a single Gaudi node. For illustration we have used the Llama 3.1 405B model running in Tensor Parallelism(TP)-16 mode spanning two Guadi2 nodes.
+> [!WARNING] 
+> !! Mutli-node calibration is an experimental feature and could have stability issues.
+
+Following section details the procedure for calibrating models that do not fit into a single Gaudi node. For illustration we have used the Llama 3.1 405B model running in Tensor Parallelism(TP)-16 mode spanning two Guadi2 nodes.<br>
+Note : Following steps are to be executed within a [Gaudi Pytorch container](https://docs.habana.ai/en/latest/Installation_Guide/Additional_Installation/Docker_Installation.html#use-intel-gaudi-containers)
 
 #### Step 1: Pre-requisites
   - Install latest [vllm-fork](https://github.com/HabanaAI/vllm-fork/blob/habana_main/README_GAUDI.md#build-and-install-vllm)

--- a/calibration/calibrate_model.sh
+++ b/calibration/calibrate_model.sh
@@ -90,6 +90,12 @@ while getopts "m:b:l:t:d:h:o:" OPT; do
     esac
 done
 
+if [[ -z "$MODEL_PATH" && -z "$FP8_DIR" && -z "$DATASET_PATH" ]]; then
+    echo "Model stub, source dataset path and output path for fp8 measurements must be provided."
+    usage
+    exit 1
+fi
+
 if [[ $TP_SIZE -gt 8 ]]; then
     MULTI_NODE_RUN=true
 fi
@@ -108,13 +114,6 @@ if $MULTI_NODE_RUN; then
         echo " !! Exiting. Invalid QUANT_CONFIG env"
         echo " Multi-node calibration requires QUANT_CONFIG to point to an empty buffer.json file. Refer https://github.com/HabanaAI/vllm-hpu-extension/tree/main/calibration#experimental-multi-node-fp8-calibration"
     fi
-fi
-
-
-if [[ -z "$MODEL_PATH" && -z "$FP8_DIR" && -z "$DATASET_PATH" ]]; then
-    echo "Model stub, source dataset path and output path for fp8 measurements must be provided."
-    usage
-    exit 1
 fi
 
 # Store the provided MODEL_PATH name in a variable

--- a/calibration/calibrate_model.sh
+++ b/calibration/calibrate_model.sh
@@ -161,6 +161,7 @@ echo ""
 echo "3/4 Postprocessing scales"
 python step-3-postprocess_measure.py -m $FP8_DIR/$MODEL_NAME/$DEVICE_TYPE/ -o inc_tmp/$MODEL_NAME/$DEVICE_TYPE/ || (echo "Error in step 3" && exit 1)
 cp inc_tmp/$MODEL_NAME/$DEVICE_TYPE/* $FP8_DIR/$MODEL_NAME/$DEVICE_TYPE/
+rm -rf inc_tmp
 echo "Step 3/4 done"
 
 if $MULTI_NODE_RUN; then

--- a/calibration/calibrate_model.sh
+++ b/calibration/calibrate_model.sh
@@ -22,6 +22,10 @@ usage() {
     echo
 }
 
+cleanup_tmp() {
+    rm -rf nc_workspace 
+    rm -rf inc_tmp
+}
 create_measure_config() {
     mkdir -p $1/$2/$3
     tmp_config="{\"method\": \"HOOKS\",\"mode\": \"MEASURE\",\"observer\": \"maxabs\",\"allowlist\": {\"types\": [], \"names\":  []},\"blocklist\": {\"types\": [], \"names\":  []},\"quantize_weight\": false,\"dump_stats_path\": \"$1/$2/$3/inc_output\"}"
@@ -43,6 +47,8 @@ function extract_last_folder_name() {
 
     echo "$last_folder"
 }
+
+cleanup_tmp
 
 EXTRA_FLAGS=""
 BATCH_SIZE=32
@@ -161,7 +167,6 @@ echo ""
 echo "3/4 Postprocessing scales"
 python step-3-postprocess_measure.py -m $FP8_DIR/$MODEL_NAME/$DEVICE_TYPE/ -o inc_tmp/$MODEL_NAME/$DEVICE_TYPE/ || (echo "Error in step 3" && exit 1)
 cp inc_tmp/$MODEL_NAME/$DEVICE_TYPE/* $FP8_DIR/$MODEL_NAME/$DEVICE_TYPE/
-rm -rf inc_tmp
 echo "Step 3/4 done"
 
 if $MULTI_NODE_RUN; then
@@ -179,4 +184,5 @@ else
     python step-4-quantize-scales.py --model $MODEL_PATH --tensor-parallel-size $TP_SIZE || (echo "Error in step 4" && exit 1)
 fi
 
+cleanup_tmp
 echo "Calibration process done"

--- a/calibration/calibrate_model.sh
+++ b/calibration/calibrate_model.sh
@@ -88,6 +88,7 @@ if $MULTI_NODE_RUN; then
         echo "Required TP size : $TP_SIZE" 
         echo "Available HPU's : $RAY_AVAILABLE_RESOURCES "
         echo "!! Exiting since not enough HPU resources available. You can run 'ray status' to see available resources"
+        echo "Refer https://github.com/vishnumadhu365/vllm-hpu-extension/edit/main/calibration/README.md#experimental-multi-node-fp8-calibration for multi-node runs"
         exit 1
     fi
 
@@ -136,7 +137,7 @@ fi
 
 if $MULTI_NODE_RUN; then
     cat $FP8_DIR/$MODEL_NAME/maxabs_measure_$DEVICE_TYPE.json > $QUANT_CONFIG
-    sleep 2000
+    sleep 2
 else
     export QUANT_CONFIG=$FP8_DIR/$MODEL_NAME/maxabs_measure_$DEVICE_TYPE.json
 fi
@@ -164,7 +165,7 @@ echo "Step 3/4 done"
 
 if $MULTI_NODE_RUN; then
     cat $FP8_DIR/$MODEL_NAME/maxabs_quant_$DEVICE_TYPE.json > $QUANT_CONFIG
-    sleep 2000
+    sleep 2
 else
     export QUANT_CONFIG=$FP8_DIR/$MODEL_NAME/maxabs_quant_$DEVICE_TYPE.json
 fi

--- a/calibration/calibrate_model.sh
+++ b/calibration/calibrate_model.sh
@@ -94,13 +94,13 @@ if $MULTI_NODE_RUN; then
         echo "Required TP size : $TP_SIZE" 
         echo "Available HPU's : $RAY_AVAILABLE_RESOURCES "
         echo "!! Exiting since not enough HPU resources available. You can run 'ray status' to see available resources"
-        echo "Refer https://github.com/vishnumadhu365/vllm-hpu-extension/edit/main/calibration/README.md#experimental-multi-node-fp8-calibration for multi-node runs"
+        echo "Refer https://github.com/HabanaAI/vllm-hpu-extension/tree/main/calibration#experimental-multi-node-fp8-calibration for multi-node runs"
         exit 1
     fi
 
     if [[ ! -e $QUANT_CONFIG ]]; then
         echo " !! Exiting. Invalid QUANT_CONFIG env"
-        echo " Multi-node calibration requires QUANT_CONFIG to point to an empty buffer.json file. Refer https://github.com/vishnumadhu365/vllm-hpu-extension/edit/main/calibration/README.md#experimental-multi-node-fp8-calibration"
+        echo " Multi-node calibration requires QUANT_CONFIG to point to an empty buffer.json file. Refer https://github.com/HabanaAI/vllm-hpu-extension/tree/main/calibration#experimental-multi-node-fp8-calibration"
     fi
 fi
 

--- a/calibration/calibrate_model.sh
+++ b/calibration/calibrate_model.sh
@@ -24,7 +24,7 @@ usage() {
 }
 
 cleanup_tmp() {
-	if [[ $(pwd) == *vllm-hpu-extension/calibration ]] then
+	if [[ $(pwd) == *vllm-hpu-extension/calibration ]]; then
 		echo " Clearing temporary directory"
 		rm -rf nc_workspace
 		rm -rf inc_tmp

--- a/calibration/step-2-measure-scales.py
+++ b/calibration/step-2-measure-scales.py
@@ -44,6 +44,7 @@ if __name__ == "__main__":
     parser.add_argument("--max-dataset-samples", type=int, default=0)
     parser.add_argument("--max-model-len", type=int, default=2048)
     parser.add_argument("-v", "--verbose", action="store_true")
+    parser.add_argument("--distributed-executor-backend", "--model", type=str, default="mp")
 
     args = parser.parse_args()
 
@@ -55,7 +56,8 @@ if __name__ == "__main__":
         quantization='inc',
         max_num_seqs=args.batch_size,
         tensor_parallel_size=args.tensor_parallel_size,
-        max_model_len=args.max_model_len
+        max_model_len=args.max_model_len,
+        distributed_executor_backend=args.distributed_executor_backend
     )
 
     sampling_params = vllm.SamplingParams(

--- a/calibration/step-2-measure-scales.py
+++ b/calibration/step-2-measure-scales.py
@@ -44,7 +44,8 @@ if __name__ == "__main__":
     parser.add_argument("--max-dataset-samples", type=int, default=0)
     parser.add_argument("--max-model-len", type=int, default=2048)
     parser.add_argument("-v", "--verbose", action="store_true")
-    parser.add_argument("--distributed-executor-backend", "--model", type=str, default="mp", help="For single node calibration use the default multiprocessing backend. For multi-node calibration use ray backend")
+    parser.add_argument("--distributed-executor-backend", "--model", type=str, default="mp", 
+                        help="For single node calibration use the default multiprocessing backend. For multi-node calibration use ray backend")
 
     args = parser.parse_args()
 

--- a/calibration/step-2-measure-scales.py
+++ b/calibration/step-2-measure-scales.py
@@ -44,7 +44,7 @@ if __name__ == "__main__":
     parser.add_argument("--max-dataset-samples", type=int, default=0)
     parser.add_argument("--max-model-len", type=int, default=2048)
     parser.add_argument("-v", "--verbose", action="store_true")
-    parser.add_argument("--distributed-executor-backend", "--model", type=str, default="mp", 
+    parser.add_argument("--distributed-executor-backend", type=str, default="mp", 
                         help="For single node calibration use the default multiprocessing backend. For multi-node calibration use ray backend")
 
     args = parser.parse_args()

--- a/calibration/step-2-measure-scales.py
+++ b/calibration/step-2-measure-scales.py
@@ -44,7 +44,7 @@ if __name__ == "__main__":
     parser.add_argument("--max-dataset-samples", type=int, default=0)
     parser.add_argument("--max-model-len", type=int, default=2048)
     parser.add_argument("-v", "--verbose", action="store_true")
-    parser.add_argument("--distributed-executor-backend", "--model", type=str, default="mp")
+    parser.add_argument("--distributed-executor-backend", "--model", type=str, default="mp", help="For single node calibration use the default multiprocessing backend. For multi-node calibration use ray backend")
 
     args = parser.parse_args()
 

--- a/calibration/step-4-quantize-scales.py
+++ b/calibration/step-4-quantize-scales.py
@@ -14,6 +14,8 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--model", type=str, required=True)
     parser.add_argument("--tensor-parallel-size", type=int, default=1)
+    parser.add_argument("--distributed-executor-backend", "--model", type=str, default="mp", 
+                        help="For single node calibration use the default multiprocessing backend. For multi-node calibration use ray backend")
 
     args = parser.parse_args()
 
@@ -23,6 +25,8 @@ if __name__ == "__main__":
         enforce_eager=True,
         dtype=torch.bfloat16,
         quantization='inc',
-        kv_cache_dtype="fp8_inc")
+        kv_cache_dtype="fp8_inc",
+        distributed_executor_backend=args.distributed_executor_backend
+    )
 
     llm.llm_engine.model_executor.shutdown()

--- a/calibration/step-4-quantize-scales.py
+++ b/calibration/step-4-quantize-scales.py
@@ -14,7 +14,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--model", type=str, required=True)
     parser.add_argument("--tensor-parallel-size", type=int, default=1)
-    parser.add_argument("--distributed-executor-backend", "--model", type=str, default="mp", 
+    parser.add_argument("--distributed-executor-backend", type=str, default="mp", 
                         help="For single node calibration use the default multiprocessing backend. For multi-node calibration use ray backend")
 
     args = parser.parse_args()

--- a/calibration/step-5-unify_measurements.py
+++ b/calibration/step-5-unify_measurements.py
@@ -168,8 +168,8 @@ def parse_args(args):
         "-g",
         "--groups",
         type=str,
-        help="Groups of cards we want to unify. Card indices seperated by commas and groups seperated by pipe character \
-                        - e.g. 0,1|2,3|4,5|6,7 card 0 measurement will be unified with card 1 measurement and so on",
+        help="Groups of cards we want to unify. Card indices seperated by commas and groups seperated by double dash '--' \
+                        - e.g. 0,1--2,3--4,5--6,7 card 0 measurement will be unified with card 1 measurement and so on",
     )
     parser.add_argument(
         "-o",
@@ -181,10 +181,12 @@ def parse_args(args):
     return parser.parse_args(args)
 
 def prepare_group_list(grouping_string):
-    # input string 0,1,2,3|4,5,6,7|8,9,10,11
-    grouping_string = grouping_string.replace(" ", "").strip("|").strip(",")
-    group_list=[group.strip(",").split(",") for group in grouping_string.split("|")]  
+    group_seperator = '--'
+    card_seperator = ','
+    grouping_string = grouping_string.replace(" ", "").strip(group_seperator).strip(card_seperator)
+    group_list=[group.strip(card_seperator).split(card_seperator) for group in grouping_string.split(group_seperator)]  
     print("Card grouping list >> {}".format(group_list))
+    return group_list
 
 def main(args):
     args = parse_args(args)

--- a/calibration/step-5-unify_measurements.py
+++ b/calibration/step-5-unify_measurements.py
@@ -167,10 +167,9 @@ def parse_args(args):
     parser.add_argument(
         "-g",
         "--groups",
-        type=list,
-        nargs="+",
-        help="groups of cards we want to unify, each group should be seperated by whitespace \
-                        - e.g. 01 23 45 67, card 0 measurement will be unified with card 1 measurement and so on",
+        type=str,
+        help="Groups of cards we want to unify. Card indices seperated by commas and groups seperated by pipe character \
+                        - e.g. 0,1|2,3|4,5|6,7 card 0 measurement will be unified with card 1 measurement and so on",
     )
     parser.add_argument(
         "-o",
@@ -181,6 +180,11 @@ def parse_args(args):
     )
     return parser.parse_args(args)
 
+def prepare_group_list(grouping_string):
+    # input string 0,1,2,3|4,5,6,7|8,9,10,11
+    grouping_string = grouping_string.replace(" ", "").strip("|").strip(",")
+    group_list=[group.strip(",").split(",") for group in grouping_string.split("|")]  
+    print("Card grouping list >> {}".format(group_list))
 
 def main(args):
     args = parse_args(args)
@@ -188,7 +192,7 @@ def main(args):
     if not os.path.exists(output_path):
         os.mkdir(output_path)
     measurements_path = args.measurements
-    groups = args.groups
+    groups = prepare_group_list(args.groups)
 
     num_jsons_drange = 0
     num_jsons_scales = 0

--- a/calibration/step-5-unify_measurements.py
+++ b/calibration/step-5-unify_measurements.py
@@ -10,7 +10,7 @@ import numpy as np
 
 
 def find_measurement_path(measurement, measurements_dir_path, scales, group_size):
-    measurment_card = measurement + "_" + str(group_size)
+    measurment_card = "_" + measurement + "_" + str(group_size)
     for measurment_file in os.listdir(measurements_dir_path):
         filename = os.fsdecode(measurment_file)
         if not filename.endswith(".json") or "_mod_list" in filename or measurment_card not in filename:


### PR DESCRIPTION
This PR enables support for multinode calibration using Ray as the distributed executor backend.
contributors : @parthabas 

Tested on : 

- 2-node Gaudi2 for FP8 quantized serving of meta-llama/Llama-3.1-405B-Instruct
- validated on all 1.19.1 stack
- vllm-fork (habana_main - 397ec534abb271574a4b22e2a78fb80c93291f03)
- vault.habana.ai/gaudi-docker/1.19.1/ubuntu22.04/habanalabs/pytorch-installer-2.5.1:latest

Updates : 

- included section for multinode training in calibration/README.md
- update measure_scales.py, quantize_scales.py to expose vllm distributed executor backend
- update calibrate_model.sh to include the multinode checks and execution
- fix unify_measurement script to address missing measurement files, wrong pattern matching etc.

Open issue : 
- unification script fails for unify to 1X cards (HS-4988) - Will be addressed in a diff PR
