### PR TITLE
Power of 2 padding fix

### DIFF
--- a/vllm_hpu_extension/bucketing.py
+++ b/vllm_hpu_extension/bucketing.py
@@ -261,6 +261,6 @@ def find_bucket(value: int, config: Tuple[int, int, int]) -> int:
         return bmin
     else:      
         next_step = round_up(value, bstep)
-        next_pow = next_pow2(value, bmin)
+        next_pow = next_pow2(value, 1)
         return min(next_step, next_pow)
 


### PR DESCRIPTION
The PR fixes an issue with extra block size padding being added to some buckets, because of incorrect  searching for the closest power of 2 value.
INFO 02-14 10:20:30 hpu_model_runner.py:1740] [Warmup][Decode][5/20] batch_size:8 num_blocks:**256** free_mem:30.88 GiB
Bucket after padding: (8, **512**, False)
INFO 02-14 10:20:30 hpu_model_runner.py:1740] [Warmup][Decode][6/20] batch_size:16 num_blocks:**128** free_mem:30.88 GiB
Bucket after padding: (16, **512**, False)
