### PR TITLE
Fix ibm granite model calibration issue.

### DIFF
--- a/calibration/step-1-prepare-calibration-dataset.py
+++ b/calibration/step-1-prepare-calibration-dataset.py
@@ -33,12 +33,19 @@ def load_chat_template(chat_template_path: str) -> str:
 def main(args):
 
     calibration_ds = get_ds(args)
+    try:
+        tokenizer = transformers.AutoTokenizer.from_pretrained(
+            args.model,
+            model_max_length=args.max_model_length,
+            padding_side="left",
+            use_fast=False,)
+    except:
+        tokenizer = transformers.AutoTokenizer.from_pretrained(
+            args.model,
+            model_max_length=args.max_model_length,
+            padding_side="left",
+            use_fast=True,)
 
-    tokenizer = transformers.AutoTokenizer.from_pretrained(
-        args.model,
-        model_max_length=args.max_model_length,
-        padding_side="left",
-        use_fast=False,)
 
     chat_template = load_chat_template(
         args.chat_template) if args.chat_template else None


### PR DESCRIPTION
For models without vocab.json, the tokenizer initialization will failed with stack as below when use_fast as True.
Add a retry to get auto tokenizer with use_fast as False. So it can use tokenizer_config.json to initialize tokenizer. 

  File "/usr/local/lib/python3.10/dist-packages/transformers/models/gpt2/tokenization_gpt2.py", line 153, in __init__
    with open(vocab_file, encoding="utf-8") as vocab_handle:
TypeError: expected str, bytes or os.PathLike object, not NoneType
Error in step 1 