### PR TITLE
Set default VLLM_PROMPT_USE_FUSEDSDPA = 0 for mllama

### DIFF
--- a/vllm_hpu_extension/flags.py
+++ b/vllm_hpu_extension/flags.py
@@ -153,7 +153,6 @@ def enabled_flags():
         "fp32_softmax": EnvFlag("VLLM_FP32_SOFTMAX", ModelType('qwen2')),
         "fsdpa": (Not(Hardware("cpu"))
                   & Kernel(fsdpa)
-                  & Kernel(fsdpa)
                   & EnvFlag("VLLM_PROMPT_USE_FUSEDSDPA",
                             Not(ModelType('qwen2')) & Not(ModelType('mllama')))),
         "compile_one_hot": (VersionRange(">=1.20.0.370") & Not(EnvFlag("PT_HPU_LAZY_MODE", "1")))

--- a/vllm_hpu_extension/flags.py
+++ b/vllm_hpu_extension/flags.py
@@ -153,9 +153,9 @@ def enabled_flags():
         "fp32_softmax": EnvFlag("VLLM_FP32_SOFTMAX", ModelType('qwen2')),
         "fsdpa": (Not(Hardware("cpu"))
                   & Kernel(fsdpa)
-                  & Not(ModelType('qwen2'))
-                  & Not(ModelType('mllama'))
-                  & EnvFlag("VLLM_PROMPT_USE_FUSEDSDPA", "1")),
+                  & Kernel(fsdpa)
+                  & EnvFlag("VLLM_PROMPT_USE_FUSEDSDPA",
+                            Not(ModelType('qwen2')) & Not(ModelType('mllama')))),
         "compile_one_hot": (VersionRange(">=1.20.0.370") & Not(EnvFlag("PT_HPU_LAZY_MODE", "1")))
     }
     environment = get_environment()

--- a/vllm_hpu_extension/flags.py
+++ b/vllm_hpu_extension/flags.py
@@ -153,7 +153,9 @@ def enabled_flags():
         "fp32_softmax": EnvFlag("VLLM_FP32_SOFTMAX", ModelType('qwen2')),
         "fsdpa": (Not(Hardware("cpu"))
                   & Kernel(fsdpa)
-                  & EnvFlag("VLLM_PROMPT_USE_FUSEDSDPA", Not(ModelType('qwen2')))),
+                  & Not(ModelType('qwen2'))
+                  & Not(ModelType('mllama'))
+                  & EnvFlag("VLLM_PROMPT_USE_FUSEDSDPA", "1")),
         "compile_one_hot": (VersionRange(">=1.20.0.370") & Not(EnvFlag("PT_HPU_LAZY_MODE", "1")))
     }
     environment = get_environment()


### PR DESCRIPTION
Using VLLM_PROMPT_USE_FUSEDSDPA = 1 with mllama causes acc regression, so we need to set it to 0 by default