### PR TITLE
Fix the method to get next_pow2

### DIFF
--- a/vllm_hpu_extension/bucketing.py
+++ b/vllm_hpu_extension/bucketing.py
@@ -245,8 +245,7 @@ def generate_decode_buckets(bs_bucket_config, blocks_bucket_config,
 
 def next_pow2(value: int, base: int) -> int:
     res = base
-    while value > 1:
-        value = (value + 1) // 2
+    while value > res:
         res *= 2
     return res
 


### PR DESCRIPTION
```python
def find_bucket(value: int, config: Tuple[int, int, int]) -> int:
    bmin, bstep, _ = config
    if value <= bmin:
        return bmin
    else:      
        next_step = round_up(value, bstep)
        next_pow = next_pow2(value, 1)
        return min(next_step, next_pow)
```
When I'm debugging, I find this function could not get the expected result. Assume the parameter `config`(prompt_bs_bucket_cfg [bmin, bstep, bmax]) is [100, 1024, 16384], then the previously obtained captured_buckets is`([*, 100], [*, 200], [*, 400], [*, 800], [*, 1024], [*, 2048], [*, 3072], [*, 4096]...)`, so If the `value` passed in func `find_bucket` is 512, its returned result should be 800, but I got the number 1024.
Debugging output:
```
next_step = round_up(value, bstep)    # 1024
next_pow = next_pow2(value, 1)         # 51200, not the expected result, should be 800
return min(next_step, next_pow)         # 1024, not the expected result, should be 800
```
