### PR TITLE
[FIX] fp8 gc compile error

### DIFF
--- a/vllm_hpu_extension/ops.py
+++ b/vllm_hpu_extension/ops.py
@@ -413,6 +413,7 @@ def scaled_fp8_quant(
         Tuple[torch.Tensor, torch.Tensor]: The output tensor in FP8 and
             scaling factor.
     """
+    htorch.core.mark_step()
     if batch_dim_padding:
         shape = (max(batch_dim_padding, input.shape[0]), *input.shape[1:])
         output = torch.empty(shape,


### PR DESCRIPTION
FP8 static quantized models with AutoFP8 give graph compiler errors during inference with vLLM. The error message was 'Invalid graph—a cycle was found in the graph. ' This PR fixes the issue.

