### PR TITLE
add 'fp32' option for softmax_mode in FusedFSDPA

### DIFF
--- a/vllm_hpu_extension/ops.py
+++ b/vllm_hpu_extension/ops.py
@@ -247,7 +247,7 @@ def prompt_attention(
         if query_heads != kv_heads:
             attn_weights = attn_weights.flatten(1, 2)
     else:
-        softmax_mode = 'fast'
+        softmax_mode = 'fp32' if 'fp32_softmax' in enabled_flags() else 'fast'
         recompute_mode = True
         valid_seq_lengths = valid_seq_lengths if attn_bias is None else None
         is_causal = attn_bias is None

--- a/vllm_hpu_extension/ops.py
+++ b/vllm_hpu_extension/ops.py
@@ -249,7 +249,8 @@ def prompt_attention(
     else:
         softmax_mode = 'fp32' if 'fp32_softmax' in enabled_flags() else 'fast'
         recompute_mode = True
-        valid_seq_lengths = valid_seq_lengths if attn_bias is None else None
+        if attn_bias is not None or 'fp32_softmax' in enabled_flags():
+            valid_seq_lengths = None
         is_causal = attn_bias is None
         attn_weights = fsdpa_op(query, key, value, attn_bias, 0.0, is_causal,
                                 scale, softmax_mode, recompute_mode,


### PR DESCRIPTION
The 'fp32' option for `softmax_mode` in [FusedFSDPA](https://docs.habana.ai/en/v1.20.0/PyTorch/Reference/Python_Packages.html#hpex-kernels-fusedsdpa) is enabled since Synapse v1.20.0.