### PR TITLE
Fix hard code of experts max number for moe kernel

### DIFF
--- a/vllm_hpu_extension/ops.py
+++ b/vllm_hpu_extension/ops.py
@@ -433,7 +433,7 @@ class VllmMixtureOfExpertsOp(torch.nn.Module):
                                                 permuted_weights=permuted_weights,
                                                 activation=activation,
                                                 experts_min=0,
-                                                experts_max=7)
+                                                experts_max=self.num_experts - 1)
 
 
 class DynamicFusedMOE(torch.nn.Module):


### PR DESCRIPTION
Fix hard code of experts max number for moe kernel，
Verifed by qwen2-moe and deepseek-v2-lite