### PR TITLE
Fix kv cache for llama3.2 model

### DIFF
--- a/vllm_hpu_extension/utils.py
+++ b/vllm_hpu_extension/utils.py
@@ -60,13 +60,7 @@ class VLLMKVCache(torch.nn.Module):
                                                 'true').lower() == 'true'
 
     def forward(self, input, cache, block_indices, block_offset):
-        """
-        NOTE: input(key/value) is None for some cases, e.g. in
-        cross attention decode stage of llama3.2 model, key
-        and value are None.
-        """
-        if input is not None:
-            insert_or_update_cache(input, cache, block_indices, block_offset)
+        insert_or_update_cache(input, cache, block_indices, block_offset)
         return cache
 
     def fetch_from_cache(self, cache, blocks):

--- a/vllm_hpu_extension/utils.py
+++ b/vllm_hpu_extension/utils.py
@@ -60,7 +60,10 @@ class VLLMKVCache(torch.nn.Module):
                                                 'true').lower() == 'true'
 
     def forward(self, input, cache, block_indices, block_offset):
-        insert_or_update_cache(input, cache, block_indices, block_offset)
+        # In cross-attention kv cache forward inputs are None in decode
+        # We don't want to store them in the cache in such case
+        if input is not None:
+            insert_or_update_cache(input, cache, block_indices, block_offset)
         return cache
 
     def fetch_from_cache(self, cache, blocks):
@@ -68,9 +71,6 @@ class VLLMKVCache(torch.nn.Module):
             return cache[:blocks.size(0)]
         else:
             return cache.index_select(0, blocks)
-        
-    def get_cache(self, cache):
-        return cache
 
 
 class ModuleFusedSDPA(torch.nn.Module):

--- a/vllm_hpu_extension/utils.py
+++ b/vllm_hpu_extension/utils.py
@@ -68,6 +68,9 @@ class VLLMKVCache(torch.nn.Module):
             return cache[:blocks.size(0)]
         else:
             return cache.index_select(0, blocks)
+        
+    def get_cache(self, cache):
+        return cache
 
 
 class ModuleFusedSDPA(torch.nn.Module):

--- a/vllm_hpu_extension/utils.py
+++ b/vllm_hpu_extension/utils.py
@@ -60,7 +60,13 @@ class VLLMKVCache(torch.nn.Module):
                                                 'true').lower() == 'true'
 
     def forward(self, input, cache, block_indices, block_offset):
-        insert_or_update_cache(input, cache, block_indices, block_offset)
+        """
+        NOTE: input(key/value) is None for some cases, e.g. in
+        cross attention decode stage of llama3.2 model, key
+        and value are None.
+        """
+        if input is not None:
+            insert_or_update_cache(input, cache, block_indices, block_offset)
         return cache
 
     def fetch_from_cache(self, cache, blocks):


### PR DESCRIPTION
In llama3.2 cross atten layer, kv cache are not updated in decode stage, in this case, we need a function that directly return key and value cache.