### PR TITLE
fix find_bucket() for large bucketing step

### DIFF
--- a/vllm_hpu_extension/bucketing.py
+++ b/vllm_hpu_extension/bucketing.py
@@ -255,11 +255,10 @@ def round_up(value: int, k: int) -> int:
 
 
 def find_bucket(value: int, config: Tuple[int, int, int]) -> int:
-    bmin, bstep, _ = config
+    bmin, bstep, bmax = config
     if value <= bmin:
         return bmin
-    else:      
-        next_step = round_up(value, bstep)
-        next_pow = next_pow2(value, bmin)
-        return min(next_step, next_pow)
 
+    next_step = round_up(value, bstep)
+    next_pow = next_pow2(value, bmin)
+    return next_pow if next_pow < bstep and next_pow <= bmax else next_step


### PR DESCRIPTION
Calling `find_bucket(value=640, config=[6, 512, 1024])` will get wrong value of `768`, which is caued by `next_pow<next_step` as the `bstep` is large in this case.
This PR fix the selection of the final value to use the same logic used in `warmup_range`:
https://github.com/HabanaAI/vllm-hpu-extension/blob/53a99024b7e4a03c2f66e8eaa22568bf67e6eaf6/vllm_hpu_extension/bucketing.py#L177-L178