### PR TITLE
Perform KV cache update on flat layout

### DIFF
--- a/vllm_hpu_extension/utils.py
+++ b/vllm_hpu_extension/utils.py
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (C) 2024 Habana Labs, Ltd. an Intel Company
+# Copyright (C) 2024-2025 Habana Labs, Ltd. an Intel Company
 #
 # This source code is licensed under the Apache 2.0 license found in the
 # LICENSE file in the root directory of this source tree.
@@ -59,8 +59,9 @@ class VLLMKVCache(torch.nn.Module):
         self.use_contiguous_pa = os.environ.get('VLLM_CONTIGUOUS_PA',
                                                 'true').lower() == 'true'
 
-    def forward(self, input, cache, block_indices, block_offset):
-        insert_or_update_cache(input, cache, block_indices, block_offset)
+    def forward(self, input, cache, block_indices, flat_indices_with_offsets):
+        insert_or_update_cache(input, cache, block_indices,
+                               flat_indices_with_offsets)
         return cache
 
     def fetch_from_cache(self, cache, blocks):


### PR DESCRIPTION
Doing KV cache update on flat layout is faster, because it allows us to avoid redundant memcopies due to small FCD in some cases.
Corresponding PR: https://github.com/HabanaAI/vllm-fork/pull/955