### PR TITLE
set default softmax mode to bf16 and add fp32 option for FusedSDPA

### DIFF
--- a/vllm_hpu_extension/ops.py
+++ b/vllm_hpu_extension/ops.py
@@ -204,9 +204,11 @@ def prompt_attention(
         if query_heads != kv_heads:
             attn_weights = attn_weights.flatten(1, 2)
     else:
-        softmax_mode = 'fast'
+        softmax_mode = 'fp32' if 'fp32_softmax' in enabled_flags() else 'None'
         recompute_mode = True
-        valid_seq_lengths = valid_seq_lengths if attn_bias is None else None
+        if attn_bias is not None or 'fp32_softmax' in enabled_flags():
+            # to ensure the accuracy of FusedSDPA with fp32 softmax
+            valid_seq_lengths = None
         is_causal = attn_bias is None
         attn_weights = fsdpa_op(query, key, value, attn_bias, 0.0, is_causal,
                                 scale, softmax_mode, recompute_mode,


### PR DESCRIPTION
- Set default softmax mode to bf16 to improve accuracy. Negligible impact on the performance is observed in the profile.
- Add fp32 softmax option and fix the accuracy issue by setting `valid_seq_lengths = None` for FusedSDPA since v1.20.0