### PR TITLE
vLLM-Ext: Full enabling of ALiBi

### DIFF
--- a/vllm_hpu_extension/features.py
+++ b/vllm_hpu_extension/features.py
@@ -50,6 +50,7 @@ def get_experimental_flags():
 def get_features():
     supported_attn_impls = ['flex_impl', 'fsdpa_impl', 'naive_impl']
     features = [
+        Value('fp32_alibi_biases', True, env_var='VLLM_ALIBI_USE_FLOAT32_BIASES'),
         Value('fp32_softmax', ModelType('qwen2')),
         Value('fused_block_softmax_adjustment', All(VersionRange(">=1.22.0.101"),
                                                     Hardware('gaudi3'),

--- a/vllm_hpu_extension/ops.py
+++ b/vllm_hpu_extension/ops.py
@@ -142,8 +142,9 @@ def flat_pa_mla(query, key_cache, value_cache, block_list, block_mapping,
 
 def flat_pa(query, key_cache, value_cache, block_list, block_mapping,
             block_bias, block_groups, block_size, scale, matmul_qk_op,
-            matmul_av_op, batch2block_matmul_op, block2batch_matmul_op,
-            keys_fetch_func, values_fetch_func, **ignored_args):
+            position_bias, matmul_av_op, batch2block_matmul_op,
+            block2batch_matmul_op, keys_fetch_func, values_fetch_func,
+            **ignored_args):
     batch_size, _, hidden_size = query.shape
     _, kv_heads, head_size = key_cache.shape
     q_heads = hidden_size // head_size
@@ -154,24 +155,36 @@ def flat_pa(query, key_cache, value_cache, block_list, block_mapping,
     value = values_fetch_func(value_cache.unflatten(0, (-1, block_size)), block_list).transpose(1, 2)
     block_bias = block_bias.view(key.size(0), 1, 1, -1)
     if kv_heads != q_heads:
-        block_bias = block_bias.unsqueeze(1)
         query = query.unflatten(1, (kv_heads, -1))
         key = key.unflatten(1, (kv_heads, 1))
         value = value.unflatten(1, (kv_heads, 1))
-        key = key.transpose(3, 4)
-    else:
-        key = key.transpose(2, 3)
+        if position_bias is not None:
+            position_bias = position_bias.unflatten(1, (kv_heads, -1))
+        if block_bias is not None:
+            block_bias = block_bias.unsqueeze(2)
+    key = key.transpose(-2, -1)
 
     attn = matmul_qk_op(query, key)
     if get_config().fp32_softmax:
         attn = attn.float()
         htcore.mark_step()
-    attn = attn + block_bias
+        if position_bias is not None:
+            position_bias = position_bias.float()
+    if position_bias is not None:
+        if attn.dtype != position_bias.dtype:
+            attn = attn.to(dtype=position_bias.dtype)
+        attn.add_(position_bias.unsqueeze(-2))
+    if block_bias is not None:
+        if attn.dtype != block_bias.dtype:
+            block_bias = block_bias.to(dtype=attn.dtype)
+        attn.add_(block_bias)
+
     attn = pipelined_pa(attn, value, block_groups, block_mapping,
                         batch_size=batch_size, matmul_av_op=matmul_av_op,
                         batch2block_matmul_op=batch2block_matmul_op, block2batch_matmul_op=block2batch_matmul_op)
     attn = block2batch(attn, block_mapping, block2batch_matmul_op)
     attn = attn.squeeze(-2)
+
     if kv_heads != q_heads:
         attn = attn.flatten(1, 2)
     return attn
@@ -220,6 +233,7 @@ def _naive_prompt_attention(
         value: torch.Tensor,
         scale: float,
         attn_bias: Optional[torch.Tensor] = None,
+        position_bias: Optional[torch.Tensor] = None,
         matmul_qk_op=torch.matmul,
         softmax_op=torch.softmax,
         matmul_av_op=torch.matmul,
@@ -234,6 +248,8 @@ def _naive_prompt_attention(
         query = query.unflatten(1, (kv_heads, -1))
         key = key.unflatten(1, (kv_heads, 1))
         value = value.unflatten(1, (kv_heads, 1))
+        if position_bias is not None:
+            position_bias = position_bias.unflatten(1, (kv_heads, -1))
         if attn_bias is not None:
             attn_bias = attn_bias.unsqueeze(2)
     attn_weights = matmul_qk_op(query * scale, key.transpose(-1, -2))
@@ -241,11 +257,25 @@ def _naive_prompt_attention(
         softmax_op = torch.softmax
         attn_weights = attn_weights.float()
         htcore.mark_step()
+        if position_bias is not None:
+            position_bias = position_bias.float()
+
+    if position_bias is not None:
+        if attn_weights.dtype != position_bias.dtype:
+            attn_weights = attn_weights.to(dtype=position_bias.dtype)
+            htcore.mark_step()
+        attn_weights.add_(position_bias)
     if attn_bias is not None:
-        attn_weights = attn_weights.add(attn_bias)
-    attn_weights = softmax_op(attn_weights, dim=-1)
+        if attn_weights.dtype != attn_bias.dtype:
+            attn_bias = attn_bias.to(dtype=attn_weights.dtype)
+        attn_weights.add_(attn_bias)
+    if get_config().fp32_softmax:
+        attn_weights = torch.softmax(attn_weights, dim=-1)
+    else:
+        attn_weights = softmax_op(attn_weights, dim=-1)
     attn_weights = attn_weights.to(query.dtype)
     attn_weights = matmul_av_op(attn_weights, value)
+
     if query_heads != kv_heads:
         attn_weights = attn_weights.flatten(1, 2)
     attn_weights = attn_weights.transpose(1, 2)


### PR DESCRIPTION
Resolves a regression in ALiBi-based models.

This is a fixed version of https://github.com/HabanaAI/vllm-hpu-extension/pull/60 which was reverted by https://github.com/HabanaAI/vllm-hpu-extension/pull/115.

This depends on the vllm-fork PR: https://github.com/HabanaAI/vllm-fork/pull/1055

All pre-commit checks are passed locally.
