### PR TITLE
Flat KV cache layout

### DIFF
--- a/vllm_hpu_extension/cache_ops.py
+++ b/vllm_hpu_extension/cache_ops.py
@@ -1,21 +1,13 @@
 ###############################################################################
-# Copyright (C) 2024 Habana Labs, Ltd. an Intel Company
+# Copyright (C) 2024-2025 Habana Labs, Ltd. an Intel Company
 #
 # This source code is licensed under the Apache 2.0 license found in the
 # LICENSE file in the root directory of this source tree.
 ###############################################################################
 
-import math
-
 import habana_frameworks.torch as htorch
 import torch
 
-
-def insert_or_update_cache(input, cache, block_indices, block_offsets):
-    if block_offsets is None:
-        cache.index_copy_(0, block_indices, input)
-    else:
-        cache.index_put_((block_indices, block_offsets), input)
 
 def swap_blocks(src, dst, block_mapping):
     if block_mapping.numel() == 0:

--- a/vllm_hpu_extension/ops.py
+++ b/vllm_hpu_extension/ops.py
@@ -295,10 +295,11 @@ def _get_all(data, *keys):
 
 
 def _include_past(tensor_str, fn_str, cache_str, args):
-    all_tensors = _get_all(args, tensor_str, fn_str, cache_str, 'block_list')
+    all_tensors = _get_all(args, tensor_str, fn_str,
+                           cache_str, 'block_list', 'block_size')
     if all(t is not None for t in all_tensors):
-        current, fn, cache, block_list = all_tensors
-        past = fn(cache, block_list)
+        current, fn, cache, block_list, block_size = all_tensors
+        past = fn(cache, block_list, block_size)
         past = past.reshape(current.size(0), -1, past.shape[2], past.shape[3])
         current = torch.concat((past, current), dim=1)
         args[tensor_str] = current

--- a/vllm_hpu_extension/utils.py
+++ b/vllm_hpu_extension/utils.py
@@ -57,11 +57,11 @@ class VLLMKVCache(torch.nn.Module):
         self.use_contiguous_pa = os.environ.get('VLLM_CONTIGUOUS_PA',
                                                 'true').lower() == 'true'
 
-    def forward(self, input, cache, block_indices_and_offsets):
+    def forward(self, input, cache, block_indices_with_offsets):
         # In cross-attention kv cache forward inputs are None in decode
         # We don't want to store them in the cache in such case
         if input is not None:
-            cache.index_copy_(0, block_indices_and_offsets, input)
+            cache.index_copy_(0, block_indices_with_offsets, input)
         return cache
 
     def fetch_from_cache(self, cache, blocks, block_size):

--- a/vllm_hpu_extension/utils.py
+++ b/vllm_hpu_extension/utils.py
@@ -64,11 +64,11 @@ class VLLMKVCache(torch.nn.Module):
             cache.index_copy_(0, slot_mapping, input)
         return cache
 
-    def fetch_from_cache(self, cache, blocks, block_size):
+    def fetch_from_cache(self, cache, blocks):
         if self.use_contiguous_pa:
-            return cache.unflatten(0, (-1, block_size))[:blocks.size(0)]
+            return cache[:blocks.size(0)]
         else:
-            return cache.unflatten(0, (-1, block_size)).index_select(0, blocks)
+            return cache.index_select(0, blocks)
 
 
 class ModuleFusedSDPA(torch.nn.Module):


### PR DESCRIPTION
Change the layout of KV cache to (num_blocks * block_size, num_kv_heads, head_size). This will improve the performance as update will be done on 1D indices which will remove unnecessary transpose and memcopies due to low FCD.
Corresponding change: https://github.com/HabanaAI/vllm-fork/pull/1106