### PR TITLE
Add support of deepseek fp8 calibration

### DIFF
--- a/calibration/README.md
+++ b/calibration/README.md
@@ -27,9 +27,6 @@ Here are some examples of how to use the script:
 > RuntimeError: [Rank:0] FATAL ERROR :: MODULE:PT_DEVMEM Allocation failed for size::939524096 (896)MB
 > ```
 
-> [!TIP]
-> You can pass `-c` to `calibrate_model.sh` to enable remote code which might be needed for some models
-
 # Run inference with FP8 models
 
 An inference with FP8 precision models using vLLM has been described in [README_GAUDI](https://github.com/HabanaAI/vllm-fork/blob/habana_main/README_GAUDI.md#quantization-fp8-inference-and-model-calibration-process) file.

--- a/calibration/README.md
+++ b/calibration/README.md
@@ -27,6 +27,9 @@ Here are some examples of how to use the script:
 > RuntimeError: [Rank:0] FATAL ERROR :: MODULE:PT_DEVMEM Allocation failed for size::939524096 (896)MB
 > ```
 
+> [!TIP]
+> You can pass `-c` to `calibrate_model.sh` to enable remote code which might be needed for some models
+
 # Run inference with FP8 models
 
 An inference with FP8 precision models using vLLM has been described in [README_GAUDI](https://github.com/HabanaAI/vllm-fork/blob/habana_main/README_GAUDI.md#quantization-fp8-inference-and-model-calibration-process) file.

--- a/calibration/calibrate_model.sh
+++ b/calibration/calibrate_model.sh
@@ -19,6 +19,7 @@ usage() {
     echo "  -b    - batch size to run the measurements at (default: 32)"
     echo "  -l    - limit number of samples in calibration dataset"
     echo "  -t    - tensor parallel size to run at (default: 1)"
+    echo "  -c    - pass trust_remote_code to vllm (default: False)"
     echo
 }
 
@@ -29,6 +30,8 @@ create_measure_config() {
 
     if [[ $model_name_lower =~ ^mixtral ]]; then
         tmp_config="{\"method\": \"HOOKS\",\"mode\": \"MEASURE\",\"observer\": \"maxabs\",\"allowlist\": {\"types\": [], \"names\":  []},\"blocklist\": {\"types\": [], \"names\":  [\"self_attn\", \"lm_head\"]},\"quantize_weight\": false,\"dump_stats_path\": \"$1/$2/$3/inc_output\"}"
+    elif [[ $model_name_lower =~ ^deepseek ]]; then
+        tmp_config="{\"method\": \"HOOKS\",\"mode\": \"MEASURE\",\"observer\": \"maxabs\",\"allowlist\": {\"types\": [], \"names\":  []},\"blocklist\": {\"types\": [], \"names\":  [\"lm_head\", \"mlp\\\.gate\\\b\"]},\"quantize_weight\": false,\"dump_stats_path\": \"$1/$2/$3/inc_output\"}"
     else
         tmp_config="{\"method\": \"HOOKS\",\"mode\": \"MEASURE\",\"observer\": \"maxabs\",\"allowlist\": {\"types\": [], \"names\":  []},\"blocklist\": {\"types\": [], \"names\":  []},\"quantize_weight\": false,\"dump_stats_path\": \"$1/$2/$3/inc_output\"}"
     fi
@@ -43,6 +46,9 @@ create_quant_config() {
     #note(kwisniewski98): mixtral models has attention masked to not cause regression in accuracy
     if [[ $model_name_lower =~ ^mixtral ]]; then
         tmp_config="{\"mode\": \"QUANTIZE\",\"observer\": \"maxabs\",\"scale_method\": \"maxabs_hw\",\"allowlist\": {\"types\": [],\"names\": []},\"blocklist\": {\"types\": [],\"names\": [\"self_attn\", \"lm_head\"]},\"dump_stats_path\": \"$1/$2/$3/inc_output\"}"
+    elif [[ $model_name_lower =~ ^deepseek ]]; then
+        tmp_config="{\"mode\": \"QUANTIZE\",\"observer\": \"maxabs\",\"scale_method\": \"maxabs_hw\", \"scale_format\": \"scalar\", \"allowlist\": {\"types\": [],\"names\": []},\"blocklist\": {\"types\": [],\"names\": [\"lm_head\", \"mlp\\\.gate\\\b\", \"latent_cache_k_nodeq\", \"latent_cache_v_nodeq\", \"matmul_qk\", \"matmul_av\", \"block2batch_matmul\"]},\"dump_stats_path\": \"$1/$2/$3/inc_output\"}"
+        echo "deepseek"
     else
         tmp_config="{\"mode\": \"QUANTIZE\",\"observer\": \"maxabs\",\"scale_method\": \"maxabs_hw\",\"allowlist\": {\"types\": [],\"names\": []},\"blocklist\": {\"types\": [],\"names\": []},\"dump_stats_path\": \"$1/$2/$3/inc_output\"}"
     fi
@@ -62,7 +68,7 @@ function extract_last_folder_name() {
 EXTRA_FLAGS=""
 BATCH_SIZE=32
 TP_SIZE=1
-while getopts "m:b:l:t:d:h:o:" OPT; do
+while getopts "m:b:l:t:d:h:o:c" OPT; do
     case ${OPT} in
         m )
             MODEL_PATH="$OPTARG"
@@ -82,6 +88,9 @@ while getopts "m:b:l:t:d:h:o:" OPT; do
         t )
             TP_SIZE="$OPTARG"
             ;;
+        c )
+            TRUST_REMOTE_CODE=true
+            ;;
         h )
             usage
             ;;
@@ -100,6 +109,7 @@ fi
 
 # Store the provided MODEL_PATH name in a variable
 MODEL_NAME=$(extract_last_folder_name "$MODEL_PATH")
+model_name_lower=$(echo "$MODEL_NAME" | tr '[:upper:]' '[:lower:]')
 
 echo "Step 0 - detecting used device type [g2, g3]"
 DEVICE_TYPE=$(python step-0-detect-device.py) || (echo "Detecting device process failed" && exit 1)
@@ -130,6 +140,16 @@ if [[ -n $LIMIT ]]; then
     EXTRA_FLAGS+="--max-dataset-samples $LIMIT "
 fi
 
+if  [[ "$model_name_lower" == *"deepseek"* ]]; then
+    EXTRA_FLAGS_STEP_2="--block-quant "
+    EXTRA_ENVS_STEP_2="VLLM_REQUANT_FP8_INC=1 VLLM_ENABLE_RUNTIME_DEQUANT=1 VLLM_MLA_DISABLE_REQUANTIZATION=1 VLLM_MOE_N_SLICE=1 VLLM_EP_SIZE=8"
+    EXTRA_FLAGS_STEP_3="--deepseek "
+    EXTRA_FLAGS_STEP_4="--block-quant "
+fi
+if [[ $TRUST_REMOTE_CODE == true ]]; then
+    EXTRA_FLAGS_STEP_2+="--trust-remote-code "
+    EXTRA_FLAGS_STEP_4+="--trust-remote-code "
+fi
 echo ""
 echo "1/4 Preparing calibration dataset"
 export QUANT_CONFIG=$FP8_DIR/$MODEL_NAME/maxabs_measure_$DEVICE_TYPE.json
@@ -138,17 +158,17 @@ echo "Step 1/4 done"
 
 echo ""
 echo "2/4 Measuring scales"
-python step-2-measure-scales.py -m $MODEL_PATH --tensor-parallel-size $TP_SIZE -d $MODEL_NAME-calibration-dataset.pkl --batch-size $BATCH_SIZE || (echo "Error in step 2" && exit 1)
+env $EXTRA_ENVS_STEP_2 python step-2-measure-scales.py -m $MODEL_PATH --tensor-parallel-size $TP_SIZE -d $MODEL_NAME-calibration-dataset.pkl --batch-size $BATCH_SIZE $EXTRA_FLAGS_STEP_2 || (echo "Error in step 2" && exit 1)
 echo "Step 2/4 done"
 
 echo ""
 echo "3/4 Postprocessing scales"
-python step-3-postprocess_measure.py -m $FP8_DIR/$MODEL_NAME/$DEVICE_TYPE/ -o inc_tmp/$MODEL_NAME/$DEVICE_TYPE/ || (echo "Error in step 3" && exit 1)
+python step-3-postprocess_measure.py -m $FP8_DIR/$MODEL_NAME/$DEVICE_TYPE/ -o inc_tmp/$MODEL_NAME/$DEVICE_TYPE/ $EXTRA_FLAGS_STEP_3 || (echo "Error in step 3" && exit 1)
 cp inc_tmp/$MODEL_NAME/$DEVICE_TYPE/* $FP8_DIR/$MODEL_NAME/$DEVICE_TYPE/
 echo "Step 3/4 done"
 
 echo ""
 echo "4/4 Quantize scales"
 export QUANT_CONFIG=$FP8_DIR/$MODEL_NAME/maxabs_quant_$DEVICE_TYPE.json
-python step-4-quantize-scales.py --model $MODEL_PATH --tensor-parallel-size $TP_SIZE || (echo "Error in step 4" && exit 1)
+python step-4-quantize-scales.py --model $MODEL_PATH --tensor-parallel-size $TP_SIZE $EXTRA_FLAGS_STEP_4 || (echo "Error in step 4" && exit 1)
 echo "Calibration process done"

--- a/calibration/calibrate_model.sh
+++ b/calibration/calibrate_model.sh
@@ -48,7 +48,6 @@ create_quant_config() {
         tmp_config="{\"mode\": \"QUANTIZE\",\"observer\": \"maxabs\",\"scale_method\": \"maxabs_hw\",\"allowlist\": {\"types\": [],\"names\": []},\"blocklist\": {\"types\": [],\"names\": [\"self_attn\", \"lm_head\"]},\"dump_stats_path\": \"$1/$2/$3/inc_output\"}"
     elif [[ $model_name_lower =~ ^deepseek ]]; then
         tmp_config="{\"mode\": \"QUANTIZE\",\"observer\": \"maxabs\",\"scale_method\": \"maxabs_hw\", \"scale_format\": \"scalar\", \"allowlist\": {\"types\": [],\"names\": []},\"blocklist\": {\"types\": [],\"names\": [\"lm_head\", \"mlp\\\.gate\\\b\", \"latent_cache_k_nodeq\", \"latent_cache_v_nodeq\", \"matmul_qk\", \"matmul_av\", \"block2batch_matmul\"]},\"dump_stats_path\": \"$1/$2/$3/inc_output\"}"
-        echo "deepseek"
     else
         tmp_config="{\"mode\": \"QUANTIZE\",\"observer\": \"maxabs\",\"scale_method\": \"maxabs_hw\",\"allowlist\": {\"types\": [],\"names\": []},\"blocklist\": {\"types\": [],\"names\": []},\"dump_stats_path\": \"$1/$2/$3/inc_output\"}"
     fi

--- a/calibration/step-2-measure-scales.py
+++ b/calibration/step-2-measure-scales.py
@@ -43,21 +43,23 @@ if __name__ == "__main__":
     parser.add_argument("--tensor-parallel-size", type=int, default=1)
     parser.add_argument("--max-dataset-samples", type=int, default=0)
     parser.add_argument("--max-num-prefill-seqs", type=int, default=1)
+    parser.add_argument("--block-quant", action="store_true", default=False)
     parser.add_argument("--max-model-len", type=int, default=2048)
+    parser.add_argument("--trust-remote-code", action="store_true", default=False)
     parser.add_argument("-v", "--verbose", action="store_true")
 
     args = parser.parse_args()
 
     calibration_ds = get_ds(args)
-
     llm = vllm.LLM(
         model=args.model,
         dtype=torch.bfloat16,
-        quantization='inc',
+        quantization='fp8' if args.block_quant else 'inc',
         max_num_seqs=args.batch_size,
         tensor_parallel_size=args.tensor_parallel_size,
         max_model_len=args.max_model_len,
-        max_num_prefill_seqs=args.max_num_prefill_seqs
+        max_num_prefill_seqs=args.max_num_prefill_seqs,
+        trust_remote_code=args.trust_remote_code,
     )
 
     sampling_params = vllm.SamplingParams(

--- a/calibration/step-2-measure-scales.py
+++ b/calibration/step-2-measure-scales.py
@@ -45,7 +45,6 @@ if __name__ == "__main__":
     parser.add_argument("--max-num-prefill-seqs", type=int, default=1)
     parser.add_argument("--block-quant", action="store_true", default=False)
     parser.add_argument("--max-model-len", type=int, default=2048)
-    parser.add_argument("--trust-remote-code", action="store_true", default=False)
     parser.add_argument("-v", "--verbose", action="store_true")
     parser.add_argument("--distributed-executor-backend", choices=["mp", "ray"], default="mp", 
                         help="For single node calibration use the default multiprocessing backend. For multi-node calibration use ray backend")
@@ -56,12 +55,12 @@ if __name__ == "__main__":
     llm = vllm.LLM(
         model=args.model,
         dtype=torch.bfloat16,
-        quantization='fp8' if args.block_quant else 'inc',
+        quantization="fp8" if args.block_quant else "inc",
         max_num_seqs=args.batch_size,
         tensor_parallel_size=args.tensor_parallel_size,
         max_model_len=args.max_model_len,
         max_num_prefill_seqs=args.max_num_prefill_seqs,
-        trust_remote_code=args.trust_remote_code,
+        trust_remote_code=True,
         distributed_executor_backend=args.distributed_executor_backend,
     )
 

--- a/calibration/step-3-postprocess_measure.py
+++ b/calibration/step-3-postprocess_measure.py
@@ -20,7 +20,6 @@ def fix_cache_inputs(json_data, args):
         k_cache_name = "k_cache"
         v_cache_name = "v_cache"
         if args.deepseek:
-            print(f"Handling deepseek model")
             attn_name = "mla_attn"
             k_cache_name = "latent_cache_k"
 

--- a/calibration/step-4-quantize-scales.py
+++ b/calibration/step-4-quantize-scales.py
@@ -14,7 +14,6 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--model", type=str, required=True)
     parser.add_argument("--tensor-parallel-size", type=int, default=1)
-    parser.add_argument("--trust-remote-code", action="store_true", default=False)
     parser.add_argument("--block-quant", action="store_true", default=False)
     parser.add_argument("--distributed-executor-backend", choices=["mp", "ray"], default="mp", 
                         help="For single node calibration use the default multiprocessing backend. For multi-node calibration use ray backend")
@@ -29,11 +28,11 @@ if __name__ == "__main__":
         tensor_parallel_size=args.tensor_parallel_size,
         enforce_eager=enforce_eager,
         dtype=torch.bfloat16,
-        quantization='fp8' if args.block_quant else 'inc',
+        quantization="fp8" if args.block_quant else "inc",
         kv_cache_dtype="fp8_inc",
         max_num_prefill_seqs=1,
-        trust_remote_code=args.trust_remote_code)
         max_model_len=128,
+        trust_remote_code=True,
         distributed_executor_backend=args.distributed_executor_backend,
     )
 

--- a/calibration/step-4-quantize-scales.py
+++ b/calibration/step-4-quantize-scales.py
@@ -14,6 +14,8 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--model", type=str, required=True)
     parser.add_argument("--tensor-parallel-size", type=int, default=1)
+    parser.add_argument("--trust-remote-code", action="store_true", default=False)
+    parser.add_argument("--block-quant", action="store_true", default=False)
 
     args = parser.parse_args()
 
@@ -25,8 +27,9 @@ if __name__ == "__main__":
         tensor_parallel_size=args.tensor_parallel_size,
         enforce_eager=enforce_eager,
         dtype=torch.bfloat16,
-        quantization='inc',
+        quantization='fp8' if args.block_quant else 'inc',
         kv_cache_dtype="fp8_inc",
-        max_num_prefill_seqs=1)
+        max_num_prefill_seqs=1,
+        trust_remote_code=args.trust_remote_code)
 
     llm.llm_engine.model_executor.shutdown()


### PR DESCRIPTION
Added:
- `-c` parameter to enable passing trust remote code to vllm
- quant config for deepseek
- block quant support for step 2 and step 4 (changing quant type to fp8)
- needed variables for deepseek measurements

Script with changes was validated for Deepseek-R1 and Mixtral 8x7B