### PR TITLE
Fix for contigious pa number of decodes blocks for exponential bucketing

### DIFF
--- a/vllm_hpu_extension/bucketing/exponential.py
+++ b/vllm_hpu_extension/bucketing/exponential.py
@@ -373,7 +373,7 @@ def warmup_range_with_limit(config: Tuple[int, int, int, int], fill=True):
     for i in range(num_buckets):
         power_unpadded = bmin * np.float_power(
             bmax / bmin, (1. / float(num_buckets - 1)) * i)
-        if power_unpadded == bmax:
+        if math.ceil(power_unpadded) >= bmax and os.environ.get('VLLM_CONTIGUOUS_PA','true').lower() == 'true':
             bucket = bmax
         else:
             bucket = math.ceil(power_unpadded / bstep) * bstep

--- a/vllm_hpu_extension/bucketing/exponential.py
+++ b/vllm_hpu_extension/bucketing/exponential.py
@@ -373,7 +373,11 @@ def warmup_range_with_limit(config: Tuple[int, int, int, int], fill=True):
     for i in range(num_buckets):
         power_unpadded = bmin * np.float_power(
             bmax / bmin, (1. / float(num_buckets - 1)) * i)
-        bucket = math.ceil(power_unpadded / bstep) * bstep
+        if power_unpadded == bmax:
+            bucket = bmax
+        else:
+            bucket = math.ceil(power_unpadded / bstep) * bstep
+        #bucket = math.ceil(power_unpadded / bstep) * bstep
         if fill and bucket in buckets:
             available_buckets = linear_buckets.difference(buckets)
             if len(available_buckets) == 0:

--- a/vllm_hpu_extension/bucketing/exponential.py
+++ b/vllm_hpu_extension/bucketing/exponential.py
@@ -374,7 +374,7 @@ def warmup_range_with_limit(config: Tuple[int, int, int, int], fill=True):
         power_unpadded = bmin * np.float_power(
             bmax / bmin, (1. / float(num_buckets - 1)) * i)
         if math.ceil(power_unpadded) >= bmax and os.environ.get(
-+               'VLLM_CONTIGUOUS_PA', 'true').lower() == 'true':
+                'VLLM_CONTIGUOUS_PA', 'true').lower() == 'true':
             bucket = bmax
         else:
             bucket = math.ceil(power_unpadded / bstep) * bstep

--- a/vllm_hpu_extension/bucketing/exponential.py
+++ b/vllm_hpu_extension/bucketing/exponential.py
@@ -373,7 +373,7 @@ def warmup_range_with_limit(config: Tuple[int, int, int, int], fill=True):
     for i in range(num_buckets):
         power_unpadded = bmin * np.float_power(
             bmax / bmin, (1. / float(num_buckets - 1)) * i)
-        if math.ceil(power_unpadded) >= bmax and os.environ.get(
+        if i == num_buckets - 1 and os.environ.get(
                 'VLLM_CONTIGUOUS_PA', 'true').lower() == 'true':
             bucket = bmax
         else:

--- a/vllm_hpu_extension/bucketing/exponential.py
+++ b/vllm_hpu_extension/bucketing/exponential.py
@@ -377,7 +377,6 @@ def warmup_range_with_limit(config: Tuple[int, int, int, int], fill=True):
             bucket = bmax
         else:
             bucket = math.ceil(power_unpadded / bstep) * bstep
-        #bucket = math.ceil(power_unpadded / bstep) * bstep
         if fill and bucket in buckets:
             available_buckets = linear_buckets.difference(buckets)
             if len(available_buckets) == 0:

--- a/vllm_hpu_extension/bucketing/exponential.py
+++ b/vllm_hpu_extension/bucketing/exponential.py
@@ -373,7 +373,8 @@ def warmup_range_with_limit(config: Tuple[int, int, int, int], fill=True):
     for i in range(num_buckets):
         power_unpadded = bmin * np.float_power(
             bmax / bmin, (1. / float(num_buckets - 1)) * i)
-        if math.ceil(power_unpadded) >= bmax and os.environ.get('VLLM_CONTIGUOUS_PA','true').lower() == 'true':
+        if math.ceil(power_unpadded) >= bmax and os.environ.get(
++               'VLLM_CONTIGUOUS_PA', 'true').lower() == 'true':
             bucket = bmax
         else:
             bucket = math.ceil(power_unpadded / bstep) * bstep


### PR DESCRIPTION
fix for contigious pa number of decodes blocks