### PR TITLE
Introduce block_softmax_adjustment kernel

### DIFF
--- a/vllm_hpu_extension/flags.py
+++ b/vllm_hpu_extension/flags.py
@@ -162,8 +162,8 @@ def enabled_flags():
                            & Not(EnvFlag("VLLM_PROMPT_USE_FUSEDSDPA", "false"))
                            & EnvFlag("VLLM_PROMPT_USE_FLEX_ATTENTION", "false")),
         "fused_block_softmax_adjustment": (Not(Hardware("cpu"))
+                                           & VersionRange(">=1.22.0.101")
                                            & Kernel(block_softmax_adjustment)
-                                           & (VersionRange(">=1.22.0.101"))
                                            & EnvFlag("VLLM_FUSED_BLOCK_SOFTMAX_ADJUSTMENT",
                                                      Not(ModelType('qwen2')) & Hardware("gaudi3"))),
     }

--- a/vllm_hpu_extension/flags.py
+++ b/vllm_hpu_extension/flags.py
@@ -164,7 +164,7 @@ def enabled_flags():
         "fused_block_softmax_adjustment": (Not(Hardware("cpu"))
                                            & Hardware("gaudi3")
                                            & Kernel(block_softmax_adjustment)
-                                           & EnvFlag("VLLM_USE_FUSED_BLOCK_SOFTMAX_ADJUSTMENT", "false")),
+                                           & EnvFlag("VLLM_USE_FUSED_BLOCK_SOFTMAX_ADJUSTMENT", "true")),
     }
     environment = get_environment()
     detected = Flags(supported_flags, environment)

--- a/vllm_hpu_extension/flags.py
+++ b/vllm_hpu_extension/flags.py
@@ -162,10 +162,10 @@ def enabled_flags():
                            & Not(EnvFlag("VLLM_PROMPT_USE_FUSEDSDPA", "false"))
                            & EnvFlag("VLLM_PROMPT_USE_FLEX_ATTENTION", "false")),
         "fused_block_softmax_adjustment": (Not(Hardware("cpu"))
-                                           & Hardware("gaudi3")
                                            & Kernel(block_softmax_adjustment)
                                            & (VersionRange(">=1.22.0.101"))
-                                           & EnvFlag("VLLM_FUSED_BLOCK_SOFTMAX_ADJUSTMENT", "true")),
+                                           & EnvFlag("VLLM_FUSED_BLOCK_SOFTMAX_ADJUSTMENT",
+                                                     Not(ModelType('qwen2')) & Hardware("gaudi3"))),
     }
     environment = get_environment()
     detected = Flags(supported_flags, environment)

--- a/vllm_hpu_extension/flags.py
+++ b/vllm_hpu_extension/flags.py
@@ -11,6 +11,7 @@ from packaging.specifiers import SpecifierSet
 
 from vllm_hpu_extension.environment import get_environment
 from vllm_hpu_extension.kernels import fsdpa
+from vllm_hpu_extension.kernels import block_softmax_adjustment
 
 
 detected = None
@@ -160,6 +161,10 @@ def enabled_flags():
                            & ModelType("llama")
                            & Not(EnvFlag("VLLM_PROMPT_USE_FUSEDSDPA", "false"))
                            & EnvFlag("VLLM_PROMPT_USE_FLEX_ATTENTION", "false")),
+        "fused_block_softmax_adjustment": (Not(Hardware("cpu"))
+                                           & Hardware("gaudi3")
+                                           & Kernel(block_softmax_adjustment)
+                                           & EnvFlag("VLLM_USE_FUSED_BLOCK_SOFTMAX_ADJUSTMENT", "false")),
     }
     environment = get_environment()
     detected = Flags(supported_flags, environment)

--- a/vllm_hpu_extension/flags.py
+++ b/vllm_hpu_extension/flags.py
@@ -164,7 +164,8 @@ def enabled_flags():
         "fused_block_softmax_adjustment": (Not(Hardware("cpu"))
                                            & Hardware("gaudi3")
                                            & Kernel(block_softmax_adjustment)
-                                           & EnvFlag("VLLM_USE_FUSED_BLOCK_SOFTMAX_ADJUSTMENT", "true")),
+                                           & (VersionRange(">=1.22.0.101"))
+                                           & EnvFlag("VLLM_FUSED_BLOCK_SOFTMAX_ADJUSTMENT", "true")),
     }
     environment = get_environment()
     detected = Flags(supported_flags, environment)

--- a/vllm_hpu_extension/kernels.py
+++ b/vllm_hpu_extension/kernels.py
@@ -5,36 +5,37 @@
 # LICENSE file in the root directory of this source tree.
 ###############################################################################
 
-from .utils import logger
 from functools import cache
 
-import torch
+
+def _kernel(name):
+    def loader(fn):
+        @cache
+        def loader_impl():
+            try:
+                print("Load", name, fn)
+                return fn()
+            except (ImportError, AttributeError):
+                from .utils import logger
+                logger().warning(f"Could not import HPU {name} kernel. "
+                                 "vLLM will use native implementation")
+        return loader_impl
+    return loader
 
 
-@cache
+@_kernel("FusedSDPA")
 def fsdpa():
-    try:
-        from habana_frameworks.torch.hpex.kernels import FusedSDPA
-        return FusedSDPA
-    except ImportError:
-        logger().warning("Could not import HPU FusedSDPA kernel. "
-                         "vLLM will use native implementation.")
+    from habana_frameworks.torch.hpex.kernels import FusedSDPA
+    return FusedSDPA
 
 
-@cache
+@_kernel("FusedRMSNorm")
 def rms_norm():
-    try:
-        from habana_frameworks.torch.hpex.normalization import FusedRMSNorm
-        return FusedRMSNorm
-    except ImportError:
-        logger().warning("Could not import HPU FusedRMSNorm kernel. "
-                         "vLLM will use forward_native implementation of RMSNorm.")
+    from habana_frameworks.torch.hpex.normalization import FusedRMSNorm
+    return FusedRMSNorm
 
 
-@cache
+@_kernel("block_softmax_adjustment")
 def block_softmax_adjustment():
-    try:
-        return torch.ops.hpu.block_softmax_adjustment
-    except ImportError:
-        logger().warning("Could not import HPU block_softmax_adjustment kernel. "
-                         "vLLM will use native implementation.")
+    import torch
+    return torch.ops.hpu.block_softmax_adjustment

--- a/vllm_hpu_extension/kernels.py
+++ b/vllm_hpu_extension/kernels.py
@@ -8,6 +8,8 @@
 from .utils import logger
 from functools import cache
 
+import torch
+
 
 @cache
 def fsdpa():
@@ -18,6 +20,7 @@ def fsdpa():
         logger().warning("Could not import HPU FusedSDPA kernel. "
                          "vLLM will use native implementation.")
 
+
 @cache
 def rms_norm():
     try:
@@ -26,3 +29,12 @@ def rms_norm():
     except ImportError:
         logger().warning("Could not import HPU FusedRMSNorm kernel. "
                          "vLLM will use forward_native implementation of RMSNorm.")
+
+
+@cache
+def block_softmax_adjustment():
+    try:
+        return torch.ops.hpu.block_softmax_adjustment
+    except ImportError:
+        logger().warning("Could not import HPU block_softmax_adjustment kernel. "
+                         "vLLM will use native implementation.")

--- a/vllm_hpu_extension/ops.py
+++ b/vllm_hpu_extension/ops.py
@@ -45,31 +45,34 @@ def pipelined_pa(attn, value, block_groups, block_mapping, batch_size,
     adjustment_target_shape = block_max.shape
     attn = attn.sub(block_max)
     attn = attn.exp()
-    attn = attn.to(value.dtype)
     block_sums = attn.sum(dim=-1, keepdim=True)
+    attn = attn.to(value.dtype)
     attn = matmul_av_op(attn, value)
-    block_max = block_max.squeeze((-1, -2))
-    block_sums = block_sums.squeeze((-1, -2))
 
-    # Calculate maximum of blocks that belong to the same sequences
-    # and cast adjustments to native dtype
-    group_max = grouped_max(block_max, batch_size, block_groups)
-    block_adjustment = (block_max - group_max).exp()
-    block_adjustment = block_adjustment.to(value.dtype)
-    sum_adjusted = block_sums.mul(block_adjustment)
+    if 'fused_block_softmax_adjustment' in enabled_flags() and block_max.dtype != torch.float16:
+        rescale = torch.ops.hpu.block_softmax_adjustment(block_max, block_sums, block_groups, batch_size)
+    else:
+        block_max = block_max.squeeze((-1, -2))
+        block_sums = block_sums.squeeze((-1, -2))
 
-    # Sum block's sums that belongs to the same sequences
-    group_sum_adjusted = block2batch(sum_adjusted, block_mapping, block2batch_matmul_op)
-    group_sum_adjusted = batch2block(group_sum_adjusted, block_mapping, batch2block_matmul_op)
-    sum_adjusted = sum_adjusted.view(*adjustment_target_shape)
-    group_sum_adjusted = group_sum_adjusted.view(*adjustment_target_shape)
-    block_adjustment = block_adjustment.view(*adjustment_target_shape)
+        # Calculate maximum of blocks that belong to the same sequences
+        # and cast adjustments to native dtype
+        group_max = grouped_max(block_max, batch_size, block_groups)
+        block_adjustment = (block_max - group_max).exp()
+        block_adjustment = block_adjustment.to(value.dtype)
+        sum_adjusted = block_sums.mul(block_adjustment)
 
-    # For stability in case some of the sums have been zeroed out during block aggretation
-    group_sum_adjusted = torch.maximum(group_sum_adjusted, sum_adjusted)
+        # Sum block's sums that belongs to the same sequences
+        group_sum_adjusted = block2batch(sum_adjusted, block_mapping, block2batch_matmul_op)
+        group_sum_adjusted = batch2block(group_sum_adjusted, block_mapping, batch2block_matmul_op)
+        sum_adjusted = sum_adjusted.view(*adjustment_target_shape)
+        group_sum_adjusted = group_sum_adjusted.view(*adjustment_target_shape)
+        block_adjustment = block_adjustment.view(*adjustment_target_shape)
 
-    # Post processing for the attention scores
-    rescale = block_adjustment.div(group_sum_adjusted)
+        # For stability in case some of the sums have been zeroed out during block aggretation
+        group_sum_adjusted = torch.maximum(group_sum_adjusted, sum_adjusted)
+        # Post processing for the attention scores
+        rescale = block_adjustment.div(group_sum_adjusted)
     attn = attn.mul(rescale)
     return attn
 
@@ -379,8 +382,8 @@ class DynamicFusedMOE(torch.nn.Module):
         htorch.core.mark_step()
         routing_weights = F.softmax(score, dim=1, dtype=torch.float32)
         routing_weights, selected_experts = torch.topk(routing_weights,
-                                                        topk,
-                                                        dim=-1)
+                                                       topk,
+                                                       dim=-1)
         routing_weights /= routing_weights.sum(dim=-1, keepdim=True)
         routing_weights = routing_weights.to(hidden_states.dtype)
 


### PR DESCRIPTION
This change introduces block_softmax_adjustment kernel, that is available since 1.22 release. The goal of this kernel is to fuse operations that were running on 2 different engines TPC & MME, and thanks to that improve overall performance of paged attention with faster execution and better pipelining.

All of the models running through the paged attention should benefit from this change. From my experiments the overall throughput gain ranges between 0.5% to 13%. Paged Attention itself is improved by 0.5% to 17%.