### PR TITLE
Porting alibi fix PR from Haihao and Tanner

### DIFF
--- a/vllm_hpu_extension/flags.py
+++ b/vllm_hpu_extension/flags.py
@@ -154,6 +154,8 @@ def enabled_flags():
         "gaudi2": Hardware("gaudi2"),
         "gaudi3": Hardware("gaudi3"),
         "cpu": Hardware("cpu"),
+        "contiguous_pa": EnvFlag("VLLM_CONTIGUOUS_PA", 'true'),
+        "fp32_alibi_biases": EnvFlag("VLLM_ALIBI_USE_FLOAT32_BIASES", '1'),
         "fp32_softmax": EnvFlag("VLLM_FP32_SOFTMAX", ModelType('qwen2') | ModelType('qwen2_moe')),
         "fsdpa": (Not(Hardware("cpu"))
                   & Kernel(fsdpa)

--- a/vllm_hpu_extension/ops.py
+++ b/vllm_hpu_extension/ops.py
@@ -84,7 +84,7 @@ def pipelined_pa(attn, value, block_groups, block_mapping, block_scales, batch_s
 
 
 def flat_pa(query, key_cache, value_cache, block_list, block_mapping,
-            block_bias, block_scales, block_groups, scale, matmul_qk_op,
+            block_bias, block_scales, block_groups, scale, position_bias, matmul_qk_op,
             matmul_av_op, batch2block_matmul_op, block2batch_matmul_op,
             keys_fetch_func, values_fetch_func):
     batch_size = query.size(0)
@@ -96,20 +96,31 @@ def flat_pa(query, key_cache, value_cache, block_list, block_mapping,
     value = values_fetch_func(value_cache, block_list).transpose(1, 2)
     block_bias = block_bias.view(key.size(0), 1, 1, -1)
     if kv_heads != q_heads:
-        block_bias = block_bias.unsqueeze(1)
         query = query.unflatten(1, (kv_heads, -1))
         key = key.unflatten(1, (kv_heads, 1))
         value = value.unflatten(1, (kv_heads, 1))
-        key = key.transpose(3, 4)
-    else:
-        key = key.transpose(2, 3)
+        if position_bias is not None:
+            position_bias = position_bias.unflatten(1, (kv_heads, -1))
+        if block_bias is not None:
+            block_bias = block_bias.unsqueeze(2)
+    key = key.transpose(-2, -1)
 
     attn = matmul_qk_op(query, key)
     if 'fp32_softmax' in enabled_flags():
         attn = attn.float()
         if not 'QUANT_CONFIG' in os.environ:    # skip mark_step for quantized models
             htcore.mark_step()
-    attn = attn + block_bias
+        if position_bias is not None:
+            position_bias = position_bias.float()
+    if position_bias is not None:
+        if attn.dtype != position_bias.dtype:
+            attn = attn.to(dtype=position_bias.dtype)
+        attn.add_(position_bias.unsqueeze(-2))
+    if block_bias is not None:
+        if attn.dtype != block_bias.dtype:
+            block_bias = block_bias.to(dtype=attn.dtype)
+        attn.add_(block_bias)
+
     attn = pipelined_pa(attn, value, block_groups, block_mapping, block_scales=block_scales,
                         batch_size=batch_size, matmul_av_op=matmul_av_op,
                         batch2block_matmul_op=batch2block_matmul_op, block2batch_matmul_op=block2batch_matmul_op)
@@ -125,6 +136,7 @@ def prompt_attention(
     key: torch.Tensor,
     value: torch.Tensor,
     attn_bias: Optional[torch.Tensor] = None,
+    position_bias: Optional[torch.Tensor] = None,
     p: float = 0.0,
     scale: Optional[float] = None,
     matmul_qk_op=torch.matmul,
@@ -143,15 +155,31 @@ def prompt_attention(
             query = query.unflatten(1, (kv_heads, -1))
             key = key.unflatten(1, (kv_heads, 1))
             value = value.unflatten(1, (kv_heads, 1))
+            if position_bias is not None:
+                position_bias = position_bias.unflatten(1, (kv_heads, -1))
             if attn_bias is not None:
                 attn_bias = attn_bias.unsqueeze(2)
-        attn_weights = matmul_qk_op(query * scale, key.transpose(-1, -2))
+        key = key.transpose(-2, -1)
+        attn_weights = matmul_qk_op(query * scale, key)
         if 'fp32_softmax' in enabled_flags():
             attn_weights = attn_weights.float()
             htcore.mark_step()
+            if position_bias is not None:
+                position_bias = position_bias.float()
+
+        if position_bias is not None:
+            if attn_weights.dtype != position_bias.dtype:
+                attn_weights = attn_weights.to(dtype=position_bias.dtype)
+                htcore.mark_step()
+            attn_weights.add_(position_bias)
         if attn_bias is not None:
-            attn_weights = attn_weights.add(attn_bias)
-        attn_weights = softmax_op(attn_weights, dim=-1)
+            if attn_weights.dtype != attn_bias.dtype:
+                attn_bias = attn_bias.to(dtype=attn_weights.dtype)
+            attn_weights.add_(attn_bias)
+        if 'fp32_softmax' in enabled_flags():
+            attn_weights = torch.softmax(attn_weights, dim=-1)
+        else:
+            attn_weights = softmax_op(attn_weights, dim=-1)
         attn_weights = attn_weights.to(query.dtype)
         attn_weights = matmul_av_op(attn_weights, value)
         if query_heads != kv_heads:


### PR DESCRIPTION
This porting is based on work from @xhaihao @tannervoas742 
https://github.com/xhaihao/vllm-hpu-extension/tree/restore_alibi_v2-fixing
https://github.com/xhaihao/vllm-fork/tree/restore_alibi_v2-fixing

And it must be work with a PR for vllm-fork (https://github.com/HabanaAI/vllm-fork/pull/1214) due to interface change.
It is tested  lm_eval GSM8k for Baichuan2-13B-Chat (score: 0.53.x) and llama-2-7b-chat-hf  (score: 0.22.x)

Refer to https://github.com/HabanaAI/vllm-fork/pull/503 for more information.
