### PR TITLE
Recover Qwen2-7B-Instruct fp8 accuracy

### DIFF
--- a/calibration/calibrate_model.sh
+++ b/calibration/calibrate_model.sh
@@ -56,7 +56,7 @@ create_quant_config() {
     fp8_config="E4M3"
     if [[ $model_name_lower == *"qwen2-7b-instruct"* ]]; then
         scale_method="MAXABS_ARBITRARY"
-        block_types="[\"VLLMKVCache\", \"Matmul\"， \"Softmax\"]"
+        block_types="[\"VLLMKVCache\", \"Matmul\", \"Softmax\"]"
         if [[ $3 == "g2" ]]; then
             fp8_config="E5M2"
         else

--- a/calibration/calibrate_model.sh
+++ b/calibration/calibrate_model.sh
@@ -40,7 +40,21 @@ create_measure_config() {
 
 create_quant_config() {
     mkdir -p $1/$2/$3
-    tmp_config="{\"mode\": \"QUANTIZE\",\"observer\": \"maxabs\",\"scale_method\": \"maxabs_hw\",\"allowlist\": {\"types\": [],\"names\": []},\"blocklist\": {\"types\": [],\"names\": []},\"dump_stats_path\": \"$1/$2/$3/inc_output\"}"
+
+    if [[ "${2,,}" == *"qwen2-7b-instruct"* ]]; then
+        scale_method="MAXABS_ARBITRARY"
+        block_types="[\"VLLMKVCache\", \"Matmul\"]"
+        if [[ "${3}" == "g2" ]]; then
+            fp8_config="E5M2"
+        else
+            fp8_config="E4M3"
+        fi
+    else
+        scale_method="maxabs_hw"
+        block_types="[]"
+        fp8_config="E4M3"
+    fi
+    tmp_config="{\"mode\": \"QUANTIZE\",\"observer\": \"maxabs\",\"scale_method\": \"${scale_method}\",\"allowlist\": {\"types\": [],\"names\": []},\"blocklist\": {\"types\": ${block_types},\"names\": []},\"dump_stats_path\": \"$1/$2/$3/inc_output\", \"fp8_config\": \"${fp8_config}\"}"
     echo "$tmp_config" > $1/$2/maxabs_quant_$3.json
 }
 


### PR DESCRIPTION
Previous:

vllm (pretrained=/models/Qwen2-7B-Instruct,dtype=bfloat16,quantization=inc,kv_cache_dtype=fp8_inc), gen_kwargs: (None), limit: None, num_fewshot: None, batch_size: 32
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.0281|±  |0.0045|
|     |       |strict-match    |     5|exact_match|↑  |0.0099|±  |0.0027|

After:
G2:
![image](https://github.com/user-attachments/assets/2d09b45f-90ba-40f1-9e7d-d482ebad749c)
G3:
![image](https://github.com/user-attachments/assets/cbfae561-c135-4e40-9243-17355ada6a40)
