### PR TITLE
fix scaled_fp8_quant parameter name to load RedHatAI fp8 model

### DIFF
--- a/vllm_hpu_extension/ops.py
+++ b/vllm_hpu_extension/ops.py
@@ -746,7 +746,7 @@ class VllmMixtureOfExpertsOpFP8(torch.nn.Module):
 def scaled_fp8_quant(
     input: torch.Tensor,
     scale: Optional[torch.Tensor] = None,
-    batch_dim_padding: Optional[int] = None,
+    num_token_padding: Optional[int] = None,
     scale_ub: Optional[torch.Tensor] = None,
     use_per_token_if_dynamic: bool = False,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
@@ -762,7 +762,7 @@ def scaled_fp8_quant(
         scale: Optional scaling factor for the FP8 quantization
         scale_ub: Optional upper bound for scaling factor in dynamic
             per token case
-        batch_dim_padding: If specified, pad the first dimension
+        num_token_padding: If specified, pad the first dimension
             of the output to at least this value.
         use_per_token_if_dynamic: Whether to do per_tensor or per_token
             in the dynamic quantization case.
@@ -770,8 +770,8 @@ def scaled_fp8_quant(
         Tuple[torch.Tensor, torch.Tensor]: The output tensor in FP8 and
             scaling factor.
     """
-    if batch_dim_padding:
-        shape = (max(batch_dim_padding, input.shape[0]), *input.shape[1:])
+    if num_token_padding:
+        shape = (max(num_token_padding, input.shape[0]), *input.shape[1:])
         output = torch.empty(shape,
                              device=input.device,
                              dtype=torch.float8_e4m3fn)


### PR DESCRIPTION
when I load [RedHatAI/Meta-Llama-3-8B-Instruct-FP8](https://huggingface.co/RedHatAI/Meta-Llama-3-8B-Instruct-FP8) to do inference on G3, the error raised. the root cause is vllm-fork rewrite the w8a8_utils.py(https://github.com/HabanaAI/vllm-fork/blob/habana_main/vllm/model_executor/layers/quantization/utils/w8a8_utils.py#L372) apply function with num_token_padding, but the name is different in vllm-hpu-extension. @Yantom1 @nirda7 @afierka-intel  @michalkuligowski 

when the PR merged, I also need improve the vllm-hpu-extension commit id in vllm-fork requirements-hpu.txt
cc: @thuang6 @linoybu 
reproduce steps:
envs:

vllm-fork: habana_main([c86b560](https://github.com/HabanaAI/vllm-fork/commit/c86b560da424dc3bcf7889e770bf74d5cad8f87b))
```python
from vllm import LLM
llm = LLM(model="RedHatAI/Meta-Llama-3-8B-Instruct-FP8")
```
```
[rank0]:   File "/usr/local/lib/python3.10/dist-packages/torch/utils/_contextlib.py", line 116, in decorate_context
[rank0]:     return func(*args, **kwargs)
[rank0]:   File "/scratch/changwa1/vllm-fork/vllm/worker/hpu_model_runner.py", line 2787, in execute_model
[rank0]:     hidden_states = self.model.forward(
[rank0]:   File "/usr/local/lib/python3.10/dist-packages/habana_frameworks/torch/hpu/graphs.py", line 751, in forward
[rank0]:     return wrapped_hpugraph_forward(
[rank0]:   File "/usr/local/lib/python3.10/dist-packages/habana_frameworks/torch/hpu/graphs.py", line 616, in wrapped_hpugraph_forward
[rank0]:     outputs = orig_fwd(*args, **kwargs)
[rank0]:   File "/scratch/changwa1/vllm-fork/vllm/worker/hpu_model_runner.py", line 459, in forward
[rank0]:     hidden_states = self.model(*args, **kwargs)
[rank0]:   File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/module.py", line 1742, in _wrapped_call_impl
[rank0]:     return self._call_impl(*args, **kwargs)
[rank0]:   File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/module.py", line 1848, in _call_impl
[rank0]:     return inner()
[rank0]:   File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/module.py", line 1796, in inner
[rank0]:     result = forward_call(*args, **kwargs)
[rank0]:   File "/scratch/changwa1/vllm-fork/vllm/model_executor/models/llama.py", line 597, in forward
[rank0]:     model_output = self.model(input_ids, positions, intermediate_tensors,
[rank0]:   File "/scratch/changwa1/vllm-fork/vllm/compilation/decorators.py", line 172, in __call__
[rank0]:     return self.forward(*args, **kwargs)
[rank0]:   File "/scratch/changwa1/vllm-fork/vllm/model_executor/models/llama.py", line 394, in forward
[rank0]:     hidden_states, residual = layer(positions, hidden_states, residual)
[rank0]:   File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/module.py", line 1742, in _wrapped_call_impl
[rank0]:     return self._call_impl(*args, **kwargs)
[rank0]:   File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/module.py", line 1848, in _call_impl
[rank0]:     return inner()
[rank0]:   File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/module.py", line 1796, in inner
[rank0]:     result = forward_call(*args, **kwargs)
[rank0]:   File "/scratch/changwa1/vllm-fork/vllm/model_executor/models/llama.py", line 301, in forward
[rank0]:     hidden_states = self.self_attn(positions=positions,
[rank0]:   File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/module.py", line 1742, in _wrapped_call_impl
[rank0]:     return self._call_impl(*args, **kwargs)
[rank0]:   File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/module.py", line 1848, in _call_impl
[rank0]:     return inner()
[rank0]:   File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/module.py", line 1796, in inner
[rank0]:     result = forward_call(*args, **kwargs)
[rank0]:   File "/scratch/changwa1/vllm-fork/vllm/model_executor/models/llama.py", line 223, in forward
[rank0]:     qkv, _ = self.qkv_proj(hidden_states)
[rank0]:   File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/module.py", line 1742, in _wrapped_call_impl
[rank0]:     return self._call_impl(*args, **kwargs)
[rank0]:   File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/module.py", line 1848, in _call_impl
[rank0]:     return inner()
[rank0]:   File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/module.py", line 1796, in inner
[rank0]:     result = forward_call(*args, **kwargs)
[rank0]:   File "/scratch/changwa1/vllm-fork/vllm/model_executor/layers/linear.py", line 491, in forward
[rank0]:     output_parallel = self.quant_method.apply(self, input_, bias)
[rank0]:   File "/scratch/changwa1/vllm-fork/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py", line 584, in apply
[rank0]:     return scheme.apply_weights(layer, x, bias=bias)
[rank0]:   File "/scratch/changwa1/vllm-fork/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_fp8.py", line 147, in apply_weights
[rank0]:     return self.fp8_linear.apply(input=x,
[rank0]:   File "/scratch/changwa1/vllm-fork/vllm/model_executor/layers/quantization/utils/w8a8_utils.py", line 372, in apply
[rank0]:     qinput, x_scale = ops.scaled_fp8_quant(
[rank0]: TypeError: scaled_fp8_quant() got an unexpected keyword argument 'num_token_padding'
```