### PR TITLE
[vlm calibration] support download HF dataset & dataset robustness

### DIFF
--- a/calibration/vlm-calibration/README.md
+++ b/calibration/vlm-calibration/README.md
@@ -3,7 +3,7 @@
 The model calibration procedure for LLM models is a little bit different than VLM, we need to change it to adapt VLM models. To simplify this process, we've provided the `calibrate_model.sh` script. It requires the following arguments:
 
 - `-m`, i.e., **model stub or path:** Path to your model (if stored locally) or the model ID from the Hugging Face Hub.
-- `-d`, i.e., **dir to the source dataset:** It's local path of HuggingFace Cache dir, aka $HF_HOME, used to store various calibration dataset. We currently hard-coded the calibration dataset to MMMU datasets, thus the provided dir must contain MMMU dataset. You could set `-d /mnt/weka/data/vlm_calibration/huggingface` to use the copy we provided. 
+- `-d`, i.e., **dir to the source dataset:** It's path of HuggingFace Cache dir, which is used to store various calibration dataset. We currently hard-coded the calibration dataset to MMMU datasets, thus the provided dir must contain MMMU dataset. Specially, the dir of dataset has two subfolders, `${your_dataset_dir}/hub` contains raw datasets, `${your_dataset_dir}/datasets` contains processed datasets. Note, if users don't provided the dataset path, we will directly download it from huggingface.
 - `-o`, i.e., **output path:** Path to the directory where the generated measurements, etc., will be stored.
 - `-t`, i.e., **tensor parallel size:** Tensor parallel size to run at.
 

--- a/calibration/vlm-calibration/README.md
+++ b/calibration/vlm-calibration/README.md
@@ -3,7 +3,7 @@
 The model calibration procedure for LLM models is a little bit different than VLM, we need to change it to adapt VLM models. To simplify this process, we've provided the `calibrate_model.sh` script. It requires the following arguments:
 
 - `-m`, i.e., **model stub or path:** Path to your model (if stored locally) or the model ID from the Hugging Face Hub.
-- `-d`, i.e., **dir to the source dataset:** It's path of HuggingFace Cache dir, which is used to store various calibration dataset. We currently hard-coded the calibration dataset to MMMU datasets, thus the provided dir must contain MMMU dataset. Specially, the dir of dataset has two subfolders, `${your_dataset_dir}/hub` contains raw datasets, `${your_dataset_dir}/datasets` contains processed datasets. Note, if users don't provided the dataset path, we will directly download it from huggingface.
+- `-d`, i.e., **dir to the source dataset:** It's path of HuggingFace Cache dir, which is used to store various calibration dataset. We currently hard-coded the calibration dataset to MMMU datasets. We add some valid check, please make sure the provided dataset path meet any of the following conditions: (1) The provided dir contain raw MMMU dataset and processed MMMU dataset. Specially, the dir of dataset has two subfolders, `${your_dataset_dir}/hub` contains raw datasets, `${your_dataset_dir}/datasets` contains processed datasets. (2) The provided dir `${your_dataset_dir}` contains processed datasets. (3) If users don't provided the dataset path, we will directly download it from huggingface.
 - `-o`, i.e., **output path:** Path to the directory where the generated measurements, etc., will be stored.
 - `-t`, i.e., **tensor parallel size:** Tensor parallel size to run at.
 

--- a/calibration/vlm-calibration/calibrate_model.sh
+++ b/calibration/vlm-calibration/calibrate_model.sh
@@ -168,6 +168,7 @@ create_quant_config $FP8_DIR $MODEL_NAME $DEVICE_TYPE
 if [[ $TP_SIZE > 1 ]]; then
     export PT_HPU_ENABLE_LAZY_COLLECTIVES=true
 fi
+export VLLM_SKIP_WARMUP=true
 max_model_len=8192
 
 

--- a/calibration/vlm-calibration/calibrate_model.sh
+++ b/calibration/vlm-calibration/calibrate_model.sh
@@ -15,7 +15,7 @@ usage() {
     echo "usage: ${0} <options>"
     echo
     echo "  -m    - [required] huggingface stub or local directory of the MODEL_PATH"
-    echo "  -d    - [required] path to source dataset (details in README)"
+    echo "  -d    - [optional] path to source dataset (details in README)"
     echo "  -o    - [required] path to output directory for fp8 measurements"
     echo "  -b    - batch size to run the measurements at (default: 32)"
     echo "  -l    - limit number of samples in calibration dataset"
@@ -111,14 +111,20 @@ while getopts "m:b:l:t:d:h:o:g:e:" OPT; do
     esac
 done
 
-if [[ -z "$MODEL_PATH" && -z "$FP8_DIR" && -z "$DATASET_PATH" ]]; then
-    echo "Model stub, source dataset path and output path for fp8 measurements must be provided."
+if [[ -z "$MODEL_PATH" && -z "$FP8_DIR" ]]; then
+    echo "Model stub and output path for fp8 measurements must be provided."
     usage
     exit 1
 fi
 
-# export HF_DATASETS_CACHE=$DATASET_PATH
-export HF_HOME=$DATASET_PATH
+if [[ -z "$DATASET_PATH" ]]; then
+    echo "Local calibration dataset path not provided. Will download it from HuggingFace."
+else
+    # export HF_DATASETS_CACHE=$DATASET_PATH
+    export HF_HOME=$DATASET_PATH
+    echo "Using local calibration dataset path: $DATASET_PATH"
+fi
+
 
 if [[ $eager_mode == "on" ]]; then
     EXTRA_FLAGS+="--enforce-eager "

--- a/calibration/vlm-calibration/calibrate_model.sh
+++ b/calibration/vlm-calibration/calibrate_model.sh
@@ -124,16 +124,16 @@ if [[ -z "$DATASET_PATH" ]]; then
 else
     echo "Using local calibration dataset path: $DATASET_PATH"
     if [[ -d "$DATASET_PATH/hub/datasets--MMMU--MMMU" && -d "$DATASET_PATH/datasets/MMMU___mmmu" ]]; then
-        # export HF_HOME=$DATASET_PATH
+        export HF_HOME="/root/.cache/huggingface"
+        echo "copying local calibration dataset $DATASET_PATH to $HF_HOME"
         mkdir -p $HF_HOME "$HF_HOME/hub" "$HF_HOME/datasets"
         cp -rf "$DATASET_PATH/hub/datasets--MMMU--MMMU" "$HF_HOME/hub"
         cp -rf "$DATASET_PATH/datasets/MMMU___mmmu" "$HF_HOME/datasets"
-        echo "copying local calibration dataset $DATASET_PATH to $HF_HOME"
     elif [[ -d "$DATASET_PATH/MMMU___mmmu" ]]; then
-        # export HF_DATASETS_CACHE=$DATASET_PATH
+        export HF_DATASETS_CACHE="/root/.cache/huggingface/datasets"
+        echo "copying local calibration dataset $DATASET_PATH to $HF_DATASETS_CACHE"
         mkdir -p $HF_DATASETS_CACHE
         cp -rf "$DATASET_PATH/MMMU___mmmu" $HF_DATASETS_CACHE
-        echo "copying local calibration dataset $DATASET_PATH to $HF_DATASETS_CACHE"
     else
         echo "Your provided dataset path doesn't contain MMMU dataset. Please refer to README for details."
     fi

--- a/calibration/vlm-calibration/calibrate_model.sh
+++ b/calibration/vlm-calibration/calibrate_model.sh
@@ -136,6 +136,7 @@ else
         cp -rf "$DATASET_PATH/MMMU___mmmu" $HF_DATASETS_CACHE
     else
         echo "Your provided dataset path doesn't contain MMMU dataset. Please refer to README for details."
+        exit 1
     fi
 fi
 

--- a/calibration/vlm-calibration/calibrate_model.sh
+++ b/calibration/vlm-calibration/calibrate_model.sh
@@ -70,6 +70,8 @@ cleanup_tmp
 
 # jump to the script directory
 cd "$(dirname "$0")"
+echo "downloading requirements"
+pip install -r requirements.txt 
 
 EXTRA_FLAGS=""
 BATCH_SIZE=32

--- a/calibration/vlm-calibration/calibrate_model.sh
+++ b/calibration/vlm-calibration/calibrate_model.sh
@@ -15,7 +15,7 @@ usage() {
     echo "usage: ${0} <options>"
     echo
     echo "  -m    - [required] huggingface stub or local directory of the MODEL_PATH"
-    echo "  -d    - [optional] path to source dataset (details in README)"
+    echo "  -d    - [optional] path to source dataset (details in README). If not provided, the dataset will be downloaded from HuggingFace."
     echo "  -o    - [required] path to output directory for fp8 measurements"
     echo "  -b    - batch size to run the measurements at (default: 32)"
     echo "  -l    - limit number of samples in calibration dataset"
@@ -70,7 +70,7 @@ cleanup_tmp
 
 # jump to the script directory
 cd "$(dirname "$0")"
-echo "downloading requirements"
+echo "downloading requirements..."
 pip install -r requirements.txt 
 
 EXTRA_FLAGS=""
@@ -122,9 +122,21 @@ fi
 if [[ -z "$DATASET_PATH" ]]; then
     echo "Local calibration dataset path not provided. Will download it from HuggingFace."
 else
-    # export HF_DATASETS_CACHE=$DATASET_PATH
-    export HF_HOME=$DATASET_PATH
     echo "Using local calibration dataset path: $DATASET_PATH"
+    if [[ -d "$DATASET_PATH/hub/datasets--MMMU--MMMU" && -d "$DATASET_PATH/datasets/MMMU___mmmu" ]]; then
+        # export HF_HOME=$DATASET_PATH
+        mkdir -p $HF_HOME "$HF_HOME/hub" "$HF_HOME/datasets"
+        cp -rf "$DATASET_PATH/hub/datasets--MMMU--MMMU" "$HF_HOME/hub"
+        cp -rf "$DATASET_PATH/datasets/MMMU___mmmu" "$HF_HOME/datasets"
+        echo "copying local calibration dataset $DATASET_PATH to $HF_HOME"
+    elif [[ -d "$DATASET_PATH/MMMU___mmmu" ]]; then
+        # export HF_DATASETS_CACHE=$DATASET_PATH
+        mkdir -p $HF_DATASETS_CACHE
+        cp -rf "$DATASET_PATH/MMMU___mmmu" $HF_DATASETS_CACHE
+        echo "copying local calibration dataset $DATASET_PATH to $HF_DATASETS_CACHE"
+    else
+        echo "Your provided dataset path doesn't contain MMMU dataset. Please refer to README for details."
+    fi
 fi
 
 

--- a/calibration/vlm-calibration/requirements.txt
+++ b/calibration/vlm-calibration/requirements.txt
@@ -1,0 +1,2 @@
+lm_eval
+datasets


### PR DESCRIPTION
This is a follow-up PR for vlm calibration, see previous PR #172 and #174 
In this PR, we enable several optimization:
- support both local dataset and remote dataset from HuggingFace
- add some validation check on dataset path
- update readme on dataset
- pip install necessary packages
