### PR TITLE
Skip dummy decode bucket when bs > num_blocks

### DIFF
--- a/vllm_hpu_extension/bucketing/linear.py
+++ b/vllm_hpu_extension/bucketing/linear.py
@@ -283,6 +283,9 @@ def generate_decode_buckets(bs_bucket_config, blocks_bucket_config,
     last_bucket = max_blocks
     for bs in bs_buckets:
         for blocks in block_buckets:
+            if bs > blocks:
+                # Skip a dummy case when bs > blocks, which cannot occur in real execution
+                continue
             if blocks >= last_bucket:
                 buckets.append((bs, last_bucket))
                 break


### PR DESCRIPTION
In linear bucketing there are cases when we create buckets with BS higher than num_blocks, which is not possible in real scenario - each sequence in a batch needs to have at least one block.