### PR TITLE
SW-229036] add fp8_kvcache support

### DIFF
--- a/vllm_hpu_extension/ops.py
+++ b/vllm_hpu_extension/ops.py
@@ -765,7 +765,6 @@ def fp8_channel_moe_prepare_weights(layer):
     htorch.core.mark_step()
     return layer
 
-
 class MoeFP8Matmul(torch.nn.Module):
     def __init__(
         self,

--- a/vllm_hpu_extension/utils.py
+++ b/vllm_hpu_extension/utils.py
@@ -70,6 +70,74 @@ class VLLMKVCache(torch.nn.Module):
         else:
             return cache.index_select(0, blocks)
 
+class VLLMFP8KVCache(VLLMKVCache):
+
+    def __init__(self, input_scale=1.0):
+        super(VLLMKVCache, self).__init__()
+        self.use_contiguous_pa = os.environ.get('VLLM_CONTIGUOUS_PA',
+                                                'true').lower() == 'true'
+        self.input_scale = input_scale
+        self.output_scale = 1.0 / self.input_scale
+
+    def quant_input(self, input):
+        return torch.ops.hpu.cast_to_fp8_v2(input, self.input_scale, False, False, torch.float8_e4m3fn)[0]
+    
+    def dequant_output(self, output):
+        return torch.ops.hpu.cast_from_fp8(output, self.output_scale, torch.bfloat16)
+
+    def forward(self, input, *args, **kwargs):
+        qinput = self.quant_input(input)
+        return super().forward(qinput, *args, **kwargs)
+
+    def fetch_from_cache(self, quant_cache, blocks, permutations=None):
+        if permutations:
+            output_cache = super().fetch_from_cache(quant_cache, blocks,
+                                                        permutations)
+            for i in range(len(output_cache)):
+                output_cache[i] = self.dequant_output(output_cache[i])
+            return output_cache
+        output_cache = super().fetch_from_cache(quant_cache, blocks)
+        return self.dequant_output(output_cache)
+
+class FP8Matmul(torch.nn.Module):
+
+    def __init__(self, scale_input=1.0, scale_other=1.0,):
+        super().__init__()
+        self.scale_input = scale_input
+        self.scale_other = scale_other
+
+    def quant_input(self, x, scale):
+        return torch.ops.hpu.cast_to_fp8_v2(
+            x, scale, False, False, torch.float8_e4m3fn
+        )[0]
+
+    def matmul_fp8(
+        self, x, other, out_dtype, scale_input_inv=None, scale_other_inv=None
+    ):
+        return torch.ops.hpu.fp8_gemm_v2(
+            A=x,
+            trans_A=False,
+            B=other,
+            trans_B=False,
+            D=None,
+            out_dtype=out_dtype,
+            A_scale_inv=scale_input_inv,
+            B_scale_inv=scale_other_inv,
+            bias=None,
+            accumulate=False,
+        )
+
+    def forward(self, input, other):
+        qinput = self.quant_input(input, self.scale_input)
+        qother = self.quant_input(other, self.scale_other)
+        output = self.matmul_fp8(
+            qinput,
+            qother,
+            out_dtype=torch.bfloat16,
+            scale_input_inv=1.0 / self.scale_input,
+            scale_other_inv=1.0 / self.scale_other,
+        )
+        return output
 
 class ModuleFusedSDPA(torch.nn.Module):
     def __init__(self, fusedSDPA):


### PR DESCRIPTION
Currently, we will leverage INC to support fp8 kv cache
Meaning, we need to specify quant_config and kv_cache_dtype = fp8_inc.

This PR would like to also walk around INC for native fp8 KV Cache support. Same method is adopted in TGI as well.

1. add FP8VLLMKVCACHE
2. add FP8MATMUL

How to run
No need to add quant_config in env var. need to use kv_cache_dtype
```
--kv_cache_dtype=fp8_inc
```

```
PT_HPU_LAZY_MODE=1 \
VLLM_SKIP_WARMUP=true \
PT_HPU_ENABLE_LAZY_COLLECTIVES=true \
PT_HPU_WEIGHT_SHARING=0 \
lm_eval --model vllm \
  --model_args "pretrained=${MODEL_PATH},tensor_parallel_size=${TP_SIZE},distributed_executor_backend=mp,trust_remote_code=true,max_model_len=4096,use_v2_block_manager=True,dtype=bfloat16,enable_expert_parallel=True,max_num_seqs=128,kv_cache_dtype=fp8_inc" \
  --tasks gsm8k --num_fewshot "5" \
  --batch_size "128" --limit 256 --log_samples --output_path gsm8k_acc_${MODEL_NAME}.json
```

```
  "results": {
    "gsm8k": {
      "alias": "gsm8k",
      "exact_match,strict-match": 0.9765625,
      "exact_match_stderr,strict-match": 0.009474047852981757,
      "exact_match,flexible-extract": 0.9765625,
      "exact_match_stderr,flexible-extract": 0.009474047852981757
    }
  },
```

Performance analysis:
see equivalent time using this PR vs using INC
this PR
![image](https://github.com/user-attachments/assets/964f3202-e765-44a3-a4e2-5f64785f3f6c)


INC
![image](https://github.com/user-attachments/assets/ff78ea80-91a3-4201-be69-ab0de3ef6823)

Future TODO:
some model also provided KV_scales in model, now I am testing with unit_scale, but it would with better accuracy using provided KV Scale.