### PR TITLE
Fix for contiguous pa number of decodes blocks for exponential bucketing #162

### DIFF
--- a/vllm_hpu_extension/bucketing/exponential.py
+++ b/vllm_hpu_extension/bucketing/exponential.py
@@ -373,7 +373,11 @@ def warmup_range_with_limit(config: Tuple[int, int, int, int], fill=True):
     for i in range(num_buckets):
         power_unpadded = bmin * np.float_power(
             bmax / bmin, (1. / float(num_buckets - 1)) * i)
-        bucket = math.ceil(power_unpadded / bstep) * bstep
+        if i == num_buckets - 1 and os.environ.get(
+                'VLLM_CONTIGUOUS_PA', 'true').lower() == 'true':
+            bucket = bmax
+        else:
+            bucket = math.ceil(power_unpadded / bstep) * bstep
         if fill and bucket in buckets:
             available_buckets = linear_buckets.difference(buckets)
             if len(available_buckets) == 0:


### PR DESCRIPTION
Fix for contiguous pa number of decodes blocks for exponential bucketing #162