### PR TITLE
[deepseek_r1]Fix decode blocks calculation for contiguous PA during warmup: porting https://github.com/HabanaAI/vllm-hpu-extension/pull/198

### DIFF
--- a/vllm_hpu_extension/bucketing.py
+++ b/vllm_hpu_extension/bucketing.py
@@ -232,7 +232,16 @@ def generate_decode_buckets(bs_bucket_config, blocks_bucket_config,
                             max_blocks):
     buckets = []
     bs_buckets = warmup_range(bs_bucket_config)
+    if os.environ.get(
+            'VLLM_DECODE_BLOCK_BUCKET_MAX') is None and os.environ.get(
+                'VLLM_CONTIGUOUS_PA', 'true').lower() == 'true':
+        blocks_bucket_config[2] = max_blocks
     block_buckets = warmup_range(blocks_bucket_config)
+    if os.environ.get('VLLM_CONTIGUOUS_PA',
+                          'true').lower() == 'true' and os.environ.get(
+                              'VLLM_DECODE_BLOCK_BUCKET_MAX'
+                          ) is None and max_blocks not in block_buckets:
+        block_buckets.append(max_blocks)
     last_bucket = max_blocks
     for bs in bs_buckets:
         for blocks in block_buckets:


### PR DESCRIPTION
"Fix decode blocks calculation for contiguous PA during warmup"

When contiguous_pa is enabled, the decode graph is not warmed-up for the max block_id. See example below, when the total number of HPU blocks is 1974, the decode graph should be warmed-up for (bs, 1974).

> INFO 05-28 03:29:33 executor_base.py:110] # HPU blocks: 1974, # CPU blocks: 954

porting https://github.com/HabanaAI/vllm-hpu-extension/pull/198 to deepseek_r1