### PR TITLE
Use sets for faster filter checks. Better long context support

### DIFF
--- a/vllm_hpu_extension/bucketing/exponential.py
+++ b/vllm_hpu_extension/bucketing/exponential.py
@@ -128,10 +128,10 @@ def generate_prompt_buckets(bs_bucket_config,
                f"seq:{seq_bucket_config}")
         raise ValueError(msg)
 
-    filtered_buckets = buckets
+    filtered_buckets = set(buckets)
     if max_num_batched_tokens is not None and max_model_len is not None:
         # Remove buckets exceeding batch token budget
-        filtered_buckets = list(
+        filtered_buckets = set(
             filter(
                 lambda bucket: bucket[0] * (bucket[1] +  bucket[2] * block_size) <= max_num_batched_tokens \
                 and bucket[1] <= max_model_len, buckets))

--- a/vllm_hpu_extension/bucketing/linear.py
+++ b/vllm_hpu_extension/bucketing/linear.py
@@ -154,10 +154,10 @@ def generate_prompt_buckets(bs_bucket_config,
                f"seq:{seq_bucket_config}")
         raise ValueError(msg)
 
-    filtered_buckets = buckets
+    filtered_buckets = set(buckets)
     if max_num_batched_tokens is not None:
         # Remove buckets exceeding batch token budget
-        filtered_buckets = list(
+        filtered_buckets = set(
             filter(
                 lambda bucket: bucket[0] * (bucket[1] +  bucket[2] * block_size) <= max_num_batched_tokens,
                 buckets))


### PR DESCRIPTION
As title states. Does not change return values since we are sorting them into lists afterwards.

Some long context models hangs due to $O(n^2)$ over a hundreds of thousands of elements.