### PR TITLE
[aice/v1.20.1] Fix deepseek distill qwen2 7b fp8 calbiration

### DIFF
--- a/calibration/calibrate_model.sh
+++ b/calibration/calibrate_model.sh
@@ -54,7 +54,7 @@ create_quant_config() {
     block_types="[\"Softmax\"]"
     block_names="[]"
     fp8_config="E4M3"
-    if [[ $model_name_lower == *"qwen2-7b-instruct"* ]]; then
+    if [[ $model_name_lower == *"deepseek-r1-distill-qwen-7b"* || $model_name_lower == *"qwen2-7b-instruct"* ]]; then
         scale_method="MAXABS_ARBITRARY"
         block_types="[\"VLLMKVCache\", \"Matmul\", \"Softmax\"]"
         if [[ $3 == "g2" ]]; then


### PR DESCRIPTION
deepseek-ai/DeepSeek-R1-Distill-Qwen-7B is a qwen2 model. It cannot use default calibration config. 
Fix https://habana.atlassian.net/browse/CS-1343
