### PR TITLE
Fix calibration execution mode

### DIFF
--- a/calibration/step-2-measure-scales.py
+++ b/calibration/step-2-measure-scales.py
@@ -45,6 +45,7 @@ if __name__ == "__main__":
     parser.add_argument("--max-num-prefill-seqs", type=int, default=1)
     parser.add_argument("--block-quant", action="store_true", default=False)
     parser.add_argument("--expert-parallel", action="store_true", default=False)
+    parser.add_argument("--enforce-eager", action="store_true", default=False)
     parser.add_argument("--max-model-len", type=int, default=2048)
     parser.add_argument("-v", "--verbose", action="store_true")
     parser.add_argument("--distributed-executor-backend", choices=["mp", "ray"], default="mp", 
@@ -56,6 +57,7 @@ if __name__ == "__main__":
     llm = vllm.LLM(
         model=args.model,
         dtype=torch.bfloat16,
+        enforce_eager=args.enforce_eager,
         quantization="fp8" if args.block_quant else "inc",
         max_num_seqs=args.batch_size,
         tensor_parallel_size=args.tensor_parallel_size,

--- a/calibration/step-4-quantize-scales.py
+++ b/calibration/step-4-quantize-scales.py
@@ -15,19 +15,17 @@ if __name__ == "__main__":
     parser.add_argument("--model", type=str, required=True)
     parser.add_argument("--tensor-parallel-size", type=int, default=1)
     parser.add_argument("--block-quant", action="store_true", default=False)
+    parser.add_argument("--enforce-eager", action="store_true", default=False)
     parser.add_argument("--expert-parallel", action="store_true", default=False)
     parser.add_argument("--distributed-executor-backend", choices=["mp", "ray"], default="mp", 
                         help="For single node calibration use the default multiprocessing backend. For multi-node calibration use ray backend")
 
     args = parser.parse_args()
 
-    hpu_lazy_mode = os.environ.get("PT_HPU_LAZY_MODE", "1")
-    enforce_eager = True if hpu_lazy_mode == "1" else False
-
     llm = vllm.LLM(
         model=args.model,
         tensor_parallel_size=args.tensor_parallel_size,
-        enforce_eager=enforce_eager,
+        enforce_eager=args.enforce_eager,
         dtype=torch.bfloat16,
         quantization="fp8" if args.block_quant else "inc",
         kv_cache_dtype="fp8_inc",


### PR DESCRIPTION
Currently, calibration is inconsistent between different steps, when it comes to eager/lazy/t.compile execution. This PR fixes it and additionally introduces `--enforce-eager` parameter to choose eager execution.