### PR TITLE
enable fsdpa for qwen2 by default

### DIFF
--- a/vllm_hpu_extension/flags.py
+++ b/vllm_hpu_extension/flags.py
@@ -165,8 +165,7 @@ def enabled_flags():
         "fp32_softmax": EnvFlag("VLLM_FP32_SOFTMAX", ModelType('qwen2') | ModelType('qwen2_moe')),
         "fsdpa": (Not(Hardware("cpu"))
                   & Kernel(fsdpa)
-                  & EnvFlag("VLLM_PROMPT_USE_FUSEDSDPA",
-                            Not(ModelType('qwen2')) & Not(ModelType('mllama')))),
+                  & EnvFlag("VLLM_PROMPT_USE_FUSEDSDPA", Not(ModelType('mllama')))),
         "compile_one_hot": (VersionRange(">=1.20.0.370") & Not(EnvFlag("PT_HPU_LAZY_MODE", "1"))),
         "flex_attention": (Not(Hardware("cpu")) & Not(EnvFlag("PT_HPU_LAZY_MODE", "1"))
                            & ModelType("llama")


### PR DESCRIPTION
This aligns with the default setting in latest habana_main.