### PR TITLE
Replace MULTI_NODE_RUN with MULTI_NODE_SETUP (1.21.2)

### DIFF
--- a/calibration/calibrate_model.sh
+++ b/calibration/calibrate_model.sh
@@ -206,7 +206,7 @@ fi
 
 echo ""
 echo "4/4 Quantize scales"
-if $MULTI_NODE_RUN; then
+if $MULTI_NODE_SETUP; then
     python3 step-4-quantize-scales.py --model $MODEL_PATH --tensor-parallel-size $TP_SIZE --distributed-executor-backend ray || (echo "Error in step 4" && exit 1)
 else
     python3 step-4-quantize-scales.py --model $MODEL_PATH --tensor-parallel-size $TP_SIZE || (echo "Error in step 4" && exit 1)


### PR DESCRIPTION
Fixes conditional statement where MULTI_NODE_SETUP should be used for distinguishing Single and Multi Node configuration (1.21.2).