### PR TITLE
Add guard for vllm import for getting engine version

### DIFF
--- a/vllm_hpu_extension/environment.py
+++ b/vllm_hpu_extension/environment.py
@@ -63,8 +63,12 @@ def set_vllm_config(cfg):
 
 
 def _get_vllm_engine_version(_):
-    import vllm.envs as envs
-    return 'v1' if envs.VLLM_USE_V1 else 'v0'
+    try:
+        import vllm.envs as envs
+        return 'v1' if envs.VLLM_USE_V1 else 'v0'
+    except:
+        logger().info("vllm module not installed, returning 'unknown' for engine version")
+        return 'unknown'
 
 
 def _get_pt_bridge_mode(_):

--- a/vllm_hpu_extension/environment.py
+++ b/vllm_hpu_extension/environment.py
@@ -66,7 +66,7 @@ def _get_vllm_engine_version(_):
     try:
         import vllm.envs as envs
         return 'v1' if envs.VLLM_USE_V1 else 'v0'
-    except:
+    except ImportError:
         logger().info("vllm module not installed, returning 'unknown' for engine version")
         return 'unknown'
 


### PR DESCRIPTION
vllm-hpu-extension is being used by other project for now and we want to avoid vllm installation. Thus, updating the snippet in this file to guard the vllm import.