### PR TITLE
Fix for calibration error TypeError: generate_responses() missing 1 required positional argument: 'args'

### DIFF
--- a/calibration/step-2-measure-scales.py
+++ b/calibration/step-2-measure-scales.py
@@ -174,13 +174,13 @@ if __name__ == "__main__":
             input_batch.append(row["input"])
             if i and i % args.batch_size == 0:
                 t_start = time.perf_counter()
-                generate_responses(llm, input_batch, args)
+                generate_responses(llm, sampling_params, input_batch, args)
                 t_end = time.perf_counter()
                 batch_done += 1
                 print(
                     f"Batch finished: {i}/{calibration_ds.shape[0]} samples done; ETA: {int((t_end - t_start) * (batch_num - batch_done) // 60)} min")
                 input_batch = []
-        generate_responses(llm, input_batch, args)
+        generate_responses(llm, sampling_params, input_batch, args)
         print(
             f"Last batch finished: {i + 1}/{calibration_ds.shape[0]} samples done")
     else:


### PR DESCRIPTION
Currently calibration fails as its missing required parameter passing. added fix for it. if no issues approve and merge
Current error message 
```
[rank0]: Traceback (most recent call last):
[rank0]:   File "/workspace/habana-internal/vllm-hpu-extension/calibration/step-2-measure-scales.py", line 177, in <module>
[rank0]:     generate_responses(llm, input_batch, args)
[rank0]: TypeError: generate_responses() missing 1 required positional argument: 'args'
Exception ignored in: <function LLMEngine.__del__ at 0x7b387202f640>
Traceback (most recent call last):
  File "/workspace/habana-internal/vllm-fork/vllm/engine/llm_engine.py", line 528, in __del__
  File "/workspace/habana-internal/vllm-fork/vllm/executor/mp_distributed_executor.py", line 134, in shutdown
  File "/workspace/habana-internal/vllm-fork/vllm/executor/mp_distributed_executor.py", line 189, in _run_workers
TypeError: 'NoneType' object is not callable
Exception ignored in: <function ExecutorBase.__del__ at 0x7b38732dfbe0>
Traceback (most recent call last):
  File "/workspace/habana-internal/vllm-fork/vllm/executor/executor_base.py", line 259, in __del__
  File "/workspace/habana-internal/vllm-fork/vllm/executor/mp_distributed_executor.py", line 134, in shutdown
  File "/workspace/habana-internal/vllm-fork/vllm/executor/mp_distributed_executor.py", line 189, in _run_workers
TypeError: 'NoneType' object is not callable
Exception ignored in: <function HPUModelRunner.__del__ at 0x7b3852d7d1b0>
Traceback (most recent call last):
  File "/workspace/habana-internal/vllm-fork/vllm/worker/hpu_model_runner.py", line 3748, in __del__
  File "/workspace/habana-internal/vllm-fork/vllm/worker/hpu_model_runner.py", line 3735, in shutdown_inc
ImportError: sys.meta_path is None, Python is likely shutting down
Error in step 2
```