### PR TITLE
Fix ModuleFusedSDPA graph break

### DIFF
--- a/vllm_hpu_extension/utils.py
+++ b/vllm_hpu_extension/utils.py
@@ -140,12 +140,10 @@ class FP8Matmul(torch.nn.Module):
         )
         return output
 
-
+from vllm_hpu_extension.kernels import fsdpa
 class ModuleFusedSDPA(torch.nn.Module):
-    def __init__(self, fusedSDPA):
+    def __init__(self):
         super().__init__()
-        assert fusedSDPA is not None, f'fusedSDPA kernel is None'
-        self._hpu_kernel_fsdpa = fusedSDPA
 
     def forward(
         self,
@@ -161,7 +159,7 @@ class ModuleFusedSDPA(torch.nn.Module):
         valid_sequence_lengths,
         padding_side="left",
     ):
-        return self._hpu_kernel_fsdpa.apply(
+        return fsdpa().apply(
             query,
             key,
             value,


### PR DESCRIPTION
Assigning the fsdpa kernel to the ModuleFusedSDPA inside the __init__ method causes graph breaks in torch compile. Since the kernel used for this class in vllm-fork is the same everywhere, making it an argument to this class is not necessary.

There were some concerns that this could break INC quantization mechanism, but I've checked it and it still works as expected.

This change will require adjusting vllm-fork to the new constructor - I'll also create a PR for vllm-fork.