### PR TITLE
Add support for FusedSDPA with window_size for Gemma3

### DIFF
--- a/vllm_hpu_extension/ops.py
+++ b/vllm_hpu_extension/ops.py
@@ -300,11 +300,13 @@ def _fsdpa_prompt_attention(
         is_causal: bool,
         attn_bias: Optional[torch.Tensor] = None,
         valid_seq_lengths: Optional[torch.Tensor] = None,
+        window_size: Optional[int] = None,
         **ignored_args
 ) -> torch.Tensor:
     query = query.transpose(1, 2)
     key = key.transpose(1, 2)
     value = value.transpose(1, 2)
+    padding_side = 'right'
     if get_config().fp32_softmax:
         softmax_mode = 'fp32'
     else:
@@ -316,9 +318,16 @@ def _fsdpa_prompt_attention(
         # TODO: causal + attn_bias is not yet supported
         is_causal = False
         valid_seq_lengths = None
+
+    if window_size is not None:
+        #causal window sdpa kernel only supports softmax None
+        softmax_mode = 'None'
+        padding_side ='left'
+
     attn_weights = fsdpa_op(query, key, value, attn_bias, 0.0, is_causal,
                             scale, softmax_mode, recompute_mode,
-                            valid_seq_lengths, 'right')
+                            valid_seq_lengths, padding_side, window_size)
+
     attn_weights = attn_weights.transpose(1, 2)
     return attn_weights
 

--- a/vllm_hpu_extension/utils.py
+++ b/vllm_hpu_extension/utils.py
@@ -160,8 +160,27 @@ class ModuleFusedSDPA(torch.nn.Module):
         recompute_mode,
         valid_sequence_lengths,
         padding_side="left",
+        window_size=None,
     ):
-        return self._hpu_kernel_fsdpa.apply(
+
+        if window_size:
+            return self._hpu_kernel_fsdpa.apply(
+                query,
+                key,
+                value,
+                attn_mask,
+                dropout_p,
+                is_causal,
+                scale,
+                softmax_mode,
+                recompute_mode,
+                valid_sequence_lengths,
+                padding_side,
+                False,
+                False,
+                window_size)
+        else:
+            return self._hpu_kernel_fsdpa.apply(
             query,
             key,
             value,


### PR DESCRIPTION
This is to use custom FusedSDPA kernel with sliding_window for Gemma3. 
This kernel is used for text input(causal + window_size) , and text+image input(attn_mask + window_size).  

Below environment variables need to be set to this feature to work. 
SLICE_SIZE=1024 (this can be changed to multiple of block size) 
PT_HPU_SDPA_BR_FACTOR=SLICE_SIZE
PT_HPU_QKV_SLICE_SEQ_LEN_THLD=SLICE_SIZE
PT_HPU_SDPA_QKV_SLICE_MODE_FWD=1
