### PR TITLE
User flags are not experimantal

### DIFF
--- a/vllm_hpu_extension/runtime.py
+++ b/vllm_hpu_extension/runtime.py
@@ -52,6 +52,7 @@ def get_config():
     environment_values = filter_defined(detected, environment_values.keys())
     feature_values = filter_defined(detected, feature_values.keys())
 
+    experimental_flags = {k: v for k, v in experimental_flags.items() if k not in user_flags.keys()}
     experimental_flag_names = experimental_flags.keys()
     if len(experimental_flag_names) > 0 and not detected.VLLM_ENABLE_EXPERIMENTAL_FLAGS:
         asterisks = 48 * '*'


### PR DESCRIPTION
If flag is in user flags don't treat it like an experimental:
With VLLM_EXPONENTIAL_BUCKETING=False:
`------------------------------------------------------------------------------
INFO 07-16 11:22:30 [runtime.py:26] Environment:`

With VLLM_SKIP_WARMUP=True: 
`------------------------------------------------------------------------------
WARNING 07-16 11:23:11 [runtime.py:61] ************************************************ Warning! ************************************************
WARNING 07-16 11:23:11 [runtime.py:62] Following environment variables are considered experimental: VLLM_SKIP_WARMUP
WARNING 07-16 11:23:11 [runtime.py:63] In future releases using those flags without VLLM_ENABLE_EXPERIMENTAL_FLAGS will trigger a fatal error.
WARNING 07-16 11:23:11 [runtime.py:64] **********************************************************************************************************
INFO 07-16 11:23:11 [runtime.py:26] Environment:
INFO 07-16 11:23:11 [runtime.py:30]     hw: gaudi2`