### PR TITLE
Fix error for PatchedModuleFusedSDPA

### DIFF
--- a/vllm_hpu_extension/ops.py
+++ b/vllm_hpu_extension/ops.py
@@ -319,14 +319,16 @@ def _fsdpa_prompt_attention(
         is_causal = False
         valid_seq_lengths = None
 
+    args = [query, key, value, attn_bias, 0.0, is_causal,
+                                scale, softmax_mode, recompute_mode,
+                                valid_seq_lengths, padding_side]
     if window_size is not None:
         #causal window sdpa kernel only supports softmax None
         softmax_mode = 'None'
         padding_side ='left'
+        args.append(window_size)
 
-    attn_weights = fsdpa_op(query, key, value, attn_bias, 0.0, is_causal,
-                            scale, softmax_mode, recompute_mode,
-                            valid_seq_lengths, padding_side, window_size)
+    attn_weights = fsdpa_op(*args)
 
     attn_weights = attn_weights.transpose(1, 2)
     return attn_weights

--- a/vllm_hpu_extension/utils.py
+++ b/vllm_hpu_extension/utils.py
@@ -140,11 +140,12 @@ class FP8Matmul(torch.nn.Module):
         )
         return output
 
-from vllm_hpu_extension.kernels import fsdpa
 
 class ModuleFusedSDPA(torch.nn.Module):
-    def __init__(self):
+    def __init__(self, fusedSDPA):
         super().__init__()
+        assert fusedSDPA is not None, f'fusedSDPA kernel is None'
+        self._hpu_kernel_fsdpa = fusedSDPA
 
     def forward(
         self,
@@ -163,7 +164,7 @@ class ModuleFusedSDPA(torch.nn.Module):
     ):
 
         if window_size:
-            return fsdpa().apply(
+            return self._hpu_kernel_fsdpa.apply(
                 query,
                 key,
                 value,
@@ -179,7 +180,7 @@ class ModuleFusedSDPA(torch.nn.Module):
                 False,
                 window_size)
         else:
-            return fsdpa().apply(
+            return self._hpu_kernel_fsdpa.apply(
             query,
             key,
             value,


### PR DESCRIPTION
window_size parameter was added for ModuleFusedSDPA,  however PatchedModuleFusedSDPA doesn't support this parameter. It seems this "fsdpa_op" in ops.py _fsdpa_prompt_attention can be any including these two and maybe others.  Passing this parameter only when we have valid info. 


Error seen without this patch.:
=========
FAILED test_lm_eval_correctness.py::test_lm_eval_correctness - TypeError: PatchedModuleFusedSDPA.forward_quant() takes from 4 to 12 positional arguments but 13 were given 