### PR TITLE
Fix: Pass correct long_context flag to warmup_range_with_limit

### DIFF
--- a/vllm_hpu_extension/bucketing/exponential.py
+++ b/vllm_hpu_extension/bucketing/exponential.py
@@ -96,7 +96,7 @@ def generate_prompt_buckets(bs_bucket_config,
     long_context = False
     if bmax >= 8192:
         long_context = True
-    seq_bucket_config = warmup_range_with_limit(seq_bucket_config, long_context=True)
+    seq_bucket_config = warmup_range_with_limit(seq_bucket_config, long_context=long_context)
 
     if prefix_caching:
         buckets_3d = []


### PR DESCRIPTION
This PR is a fix to correct the `long_context` argument passed to `warmup_range_with_limit`.

The argument was hardcoded to `True`, ignoring the actual value determined by `bmax`. Now it correctly uses the` long_context` variable based on the `bmax` threshold.