### PR TITLE
Choose different bucket when SLICE FusedSDPA is in use

### DIFF
--- a/vllm_hpu_extension/bucketing/common.py
+++ b/vllm_hpu_extension/bucketing/common.py
@@ -61,7 +61,7 @@ class HPUBucketingManager():
             self.slice_size = get_config().PT_HPU_SDPA_BC_FACTOR if \
                 get_config().PT_HPU_SDPA_BC_FACTOR is not None else 1024
             self.slice_thld = get_config().VLLM_FUSEDSDPA_SLIDE_THLD if \
-                get_config().VLLM_FUSEDSDPA_SLIDE_THLD is not None else 10240
+                get_config().VLLM_FUSEDSDPA_SLIDE_THLD is not None else 8192
 
     def get_bucketing_strategy(self):
         strategy = None

--- a/vllm_hpu_extension/bucketing/common.py
+++ b/vllm_hpu_extension/bucketing/common.py
@@ -92,7 +92,7 @@ class HPUBucketingManager():
             if self.use_sliding_window:
                 self.prompt_buckets = [t for t in self.prompt_buckets
                     if t[1] < self.slice_thld or (
-                    t[1] >=self.slice_thld and t[1] % self.slice_size == 0)]
+                    t[1] >= self.slice_thld and t[1] % self.slice_size == 0)]
 
             self.log_generate_info(True)
         else:

--- a/vllm_hpu_extension/features.py
+++ b/vllm_hpu_extension/features.py
@@ -37,7 +37,8 @@ def get_user_flags():
         
         # Sliding window flags
         Env('PT_HPU_SDPA_QKV_SLICE_MODE_FWD', boolean),
-        Env('PT_HPU_QKV_SLICE_SEQ_LEN_THLD', int)
+        Env('PT_HPU_SDPA_BC_FACTOR', int),
+        Env('VLLM_FUSEDSDPA_SLIDE_THLD', int),
     ]
     return to_dict(flags)
 


### PR DESCRIPTION
Customer requested us to use different BUCKET size for shorter length and longer length. 
We are doing this. 
 - If seq_len is smaller than SLICE_THLD, then use FusedSDPA, and it will use BUCKET_STEP size.
- If seq_len is grater than SLICE_THLD, then use FusedSDPA with slice kernel, and it will use SLICE_SIZE(1024 default).  