### PR TITLE
Modify ops.py for hunyuan fp8 model implementation

### DIFF
--- a/vllm_hpu_extension/ops.py
+++ b/vllm_hpu_extension/ops.py
@@ -542,6 +542,7 @@ class VllmMixtureOfExpertsOp(torch.nn.Module):
             experts_max=self.experts_max,
             **kwargs
         )
+        print('\nVllmMixtureOfExpertsOp\n')
         return final_hidden_states
 
 
@@ -567,6 +568,7 @@ class DynamicFusedMOE(torch.nn.Module):
             permuted_weights=True,
             activation="silu",
         )
+        print('\nDynamicFusedMOE\n')
 
         return final_hidden_states.view(-1, hidden_states.shape[1])
 
@@ -965,6 +967,7 @@ class VllmMixtureOfExpertsOpFP8(torch.nn.Module):
             experts_max=self.experts_max,
             **kwargs
         )
+        print('\nVllmMixtureOfExpertsOpFP8\n')
         return final_hidden_states
 
 
@@ -1057,7 +1060,7 @@ class VllmMixtureOfExpertsOpFP8PerChannel(torch.nn.Module):
                                     experts_min=self.experts_min,
                                     experts_max=self.experts_max,
                                     **kwargs)
-
+        print('\nVllmMixtureOfExpertsOpFP8PerChannel\n')
         return final_hidden_states
 
 

--- a/vllm_hpu_extension/ops.py
+++ b/vllm_hpu_extension/ops.py
@@ -1040,7 +1040,7 @@ class VllmMixtureOfExpertsOpFP8PerChannel(torch.nn.Module):
                                     **kwargs)
         else:
             x_scale = self.w13_input_scale.data
-            w2_input_scale =  self.w2_input_scale.data
+            w2_input_scale = self.w2_input_scale
             x_fp8 = torch.ops.hpu.cast_to_fp8_v2(x, 1.0/x_scale, False, False, torch.float8_e4m3fn)[0]
             final_hidden_states = torch.ops.hpu.mixture_of_experts(
                                     hidden_states=x_fp8,

--- a/vllm_hpu_extension/ops.py
+++ b/vllm_hpu_extension/ops.py
@@ -847,6 +847,11 @@ def fp8_channel_moe_prepare_weights(layer):
         layer.moe_op.w2_input_scale = [layer.w2_input_scale.data.clone() for _ in range(layer.moe_op.num_experts)]
 
     htorch.core.mark_step()
+    
+    
+    print('\n\n\n',os.getenv("VLLM_HPU_FORCE_HUNYUAN_FP8"),'\n\n\n')
+    
+    
     return layer
 
 class MoeFP8Matmul(torch.nn.Module):

--- a/vllm_hpu_extension/ops.py
+++ b/vllm_hpu_extension/ops.py
@@ -846,7 +846,7 @@ def fp8_channel_moe_prepare_weights(layer):
     if hasattr(layer, "w13_input_scale"):
         layer.moe_op.w13_input_scale = layer.w13_input_scale
     if hasattr(layer, "w2_input_scale"):
-        # for hunyuan, clone input_scale scalar for each expert
+        # for hunyuan, clone input_scale for each expert
         if get_config().model_type == "hunyuan":
             layer.moe_op.w2_input_scale = [layer.w2_input_scale.data.clone() for _ in range(layer.moe_op.num_experts)]
         else:

--- a/vllm_hpu_extension/ops.py
+++ b/vllm_hpu_extension/ops.py
@@ -839,7 +839,7 @@ def fp8_channel_moe_prepare_weights(layer):
             layer.moe_op.w2_list[index].set_scale_inv_fp8(weight_scale_inv)
         
         # change the scalar scale_inv_fp8 to meet the channel size
-        if len(layer.moe_op.w2_list[index].scale_inv_fp8) == 0 and len(layer.moe_op.w13_list[index].scale_inv_fp8) == 1:
+        if len(layer.moe_op.w2_list[index].scale_inv_fp8.shape) == 0 and len(layer.moe_op.w13_list[index].scale_inv_fp8.shape) == 1:
             layer.moe_op.w2_list[index].set_scale_inv_fp8(layer.moe_op.w2_list[index].scale_inv_fp8.repeat(layer.w2_weight.shape[1]).flatten().clone())
             layer.moe_op.w13_list[index].set_scale_inv_fp8(layer.moe_op.w13_list[index].scale_inv_fp8.reshape(2,1).repeat(1,layer.w13_weight.shape[1]//2).flatten().clone())
             

--- a/vllm_hpu_extension/ops.py
+++ b/vllm_hpu_extension/ops.py
@@ -840,8 +840,12 @@ def fp8_channel_moe_prepare_weights(layer):
         
         # change the scalar scale_inv_fp8 to meet the channel size
         if len(layer.moe_op.w2_list[index].scale_inv_fp8.shape) == 0 and len(layer.moe_op.w13_list[index].scale_inv_fp8.shape) == 1:
-            layer.moe_op.w2_list[index].set_scale_inv_fp8(layer.moe_op.w2_list[index].scale_inv_fp8.repeat(layer.w2_weight.shape[1]).flatten().clone())
-            layer.moe_op.w13_list[index].set_scale_inv_fp8(layer.moe_op.w13_list[index].scale_inv_fp8.reshape(2,1).repeat(1,layer.w13_weight.shape[1]//2).flatten().clone())
+            layer.moe_op.w2_list[index].set_scale_inv_fp8(
+                layer.moe_op.w2_list[index].scale_inv_fp8.repeat(layer.w2_weight.shape[1]).flatten().clone()
+            )
+            layer.moe_op.w13_list[index].set_scale_inv_fp8(
+                layer.moe_op.w13_list[index].scale_inv_fp8.reshape(2,1).repeat(1,layer.w13_weight.shape[1]//2).flatten().clone()
+            )
             
     if hasattr(layer, "w13_input_scale"):
         layer.moe_op.w13_input_scale = layer.w13_input_scale

--- a/vllm_hpu_extension/ops.py
+++ b/vllm_hpu_extension/ops.py
@@ -838,10 +838,13 @@ def fp8_channel_moe_prepare_weights(layer):
             weight_scale_inv = torch.ones(layer.w2_weight[index].shape[:-1], dtype=torch.bfloat16, device=layer.w2_weight[index].device)
             layer.moe_op.w2_list[index].set_scale_inv_fp8(weight_scale_inv)
             
+        layer.moe_op.w2_list[index].set_scale_inv_fp8(layer.moe_op.w2_list[index].scale_inv_fp8.repeat(4096).flatten().clone())
+        layer.moe_op.w13_list[index].set_scale_inv_fp8(layer.moe_op.w13_list[index].scale_inv_fp8.reshape(2,1).repeat(1,3072).flatten().clone())
+            
     if hasattr(layer, "w13_input_scale"):
         layer.moe_op.w13_input_scale = layer.w13_input_scale
     if hasattr(layer, "w2_input_scale"):
-        layer.moe_op.w2_input_scale = layer.w2_input_scale
+        layer.moe_op.w2_input_scale = [layer.w2_input_scale.data.clone() for _ in range(layer.moe_op.num_experts)]
 
     htorch.core.mark_step()
     return layer

--- a/vllm_hpu_extension/ops.py
+++ b/vllm_hpu_extension/ops.py
@@ -843,6 +843,11 @@ def fp8_channel_moe_prepare_weights(layer):
             layer.moe_op.w2_list[index].set_scale_inv_fp8(
                 layer.moe_op.w2_list[index].scale_inv_fp8.repeat(layer.w2_weight.shape[1]).flatten().clone()
             )
+            '''
+            When weight scale is per tensor quantized, w1 and w3 are combined so the shape of their weight scales become [2],
+            but MoE requires [2 * num_experts], so it has to be reshaped as [2, 1],
+            and repeated to [2, num_experts] and then flattened to [2 * num_experts].
+            '''
             layer.moe_op.w13_list[index].set_scale_inv_fp8(
                 layer.moe_op.w13_list[index].scale_inv_fp8.reshape(2,1).repeat(1,layer.w13_weight.shape[1]//2).flatten().clone()
             )

--- a/vllm_hpu_extension/ops.py
+++ b/vllm_hpu_extension/ops.py
@@ -846,7 +846,7 @@ def fp8_channel_moe_prepare_weights(layer):
     if hasattr(layer, "w13_input_scale"):
         layer.moe_op.w13_input_scale = layer.w13_input_scale
     if hasattr(layer, "w2_input_scale"):
-        # for hunyuan, clone input_scale for each expert
+        # for hunyuan, clone input_scale scalar for each expert
         if get_config().model_type == "hunyuan":
             layer.moe_op.w2_input_scale = [layer.w2_input_scale.data.clone() for _ in range(layer.moe_op.num_experts)]
         else:

--- a/vllm_hpu_extension/ops.py
+++ b/vllm_hpu_extension/ops.py
@@ -849,7 +849,8 @@ def fp8_channel_moe_prepare_weights(layer):
     htorch.core.mark_step()
     
     
-    print('\n\n\n', layer.moe_op.w13_list[0].weight.shape, layer.moe_op.w2_list[0].weight.shape, '\n\n\n')
+    #print('\n\n\n', layer.moe_op.w13_list[0].weight.shape, layer.moe_op.w2_list[0].weight.shape, '\n\n\n')
+    print('\n\n\n', get_config(), '\n\n\n')
     
     
     return layer

--- a/vllm_hpu_extension/ops.py
+++ b/vllm_hpu_extension/ops.py
@@ -849,7 +849,8 @@ def fp8_channel_moe_prepare_weights(layer):
     htorch.core.mark_step()
     
     
-    print('\n\n\n',layer,'\n\n\n')
+    print('\n\n\n',type(layer),'\n\n\n')
+    print('\n\n\n',layer.copy(),'\n\n\n')
     
     
     return layer

--- a/vllm_hpu_extension/ops.py
+++ b/vllm_hpu_extension/ops.py
@@ -852,8 +852,8 @@ def fp8_channel_moe_prepare_weights(layer):
             )
             '''
             When weight scale is per tensor quantized, w1 and w3 are combined so the shape of their weight scales become [2],
-            but MoE requires [2 * num_experts], so it has to be reshaped as [2, 1],
-            and repeated to [2, num_experts] and then flattened to [2 * num_experts].
+            but MoE requires [2 * out_channels], so it has to be reshaped as [2, 1],
+            and repeated to [2, out_channels] and then flattened to [2 * out_channels].
             '''
             layer.moe_op.w13_list[index].set_scale_inv_fp8(
                 layer.moe_op.w13_list[index].scale_inv_fp8.reshape(2,1).repeat(1,layer.w13_weight.shape[1]//2).flatten().clone()

--- a/vllm_hpu_extension/ops.py
+++ b/vllm_hpu_extension/ops.py
@@ -845,9 +845,10 @@ def fp8_channel_moe_prepare_weights(layer):
     if hasattr(layer, "w13_input_scale"):
         layer.moe_op.w13_input_scale = layer.w13_input_scale
     if hasattr(layer, "w2_input_scale"):
-        layer.moe_op.w2_input_scale = layer.w2_input_scale
         if get_config().model_type == "hunyuan":
             layer.moe_op.w2_input_scale = [layer.w2_input_scale.data.clone() for _ in range(layer.moe_op.num_experts)]
+        else:
+            layer.moe_op.w2_input_scale = layer.w2_input_scale
 
     htorch.core.mark_step()
     return layer

--- a/vllm_hpu_extension/ops.py
+++ b/vllm_hpu_extension/ops.py
@@ -1044,7 +1044,12 @@ class VllmMixtureOfExpertsOpFP8PerChannel(torch.nn.Module):
                                     **kwargs)
         else:
             x_scale = self.w13_input_scale.data
-            w2_input_scale = self.w2_input_scale
+            
+            if get_config().model_type == "hunyuan":
+                w2_input_scale = self.w2_input_scale
+            else:
+                w2_input_scale = self.w2_input_scale.data
+                
             x_fp8 = torch.ops.hpu.cast_to_fp8_v2(x, 1.0/x_scale, False, False, torch.float8_e4m3fn)[0]
             final_hidden_states = torch.ops.hpu.mixture_of_experts(
                                     hidden_states=x_fp8,

--- a/vllm_hpu_extension/ops.py
+++ b/vllm_hpu_extension/ops.py
@@ -849,8 +849,7 @@ def fp8_channel_moe_prepare_weights(layer):
     htorch.core.mark_step()
     
     
-    print('\n\n\n',type(layer),'\n\n\n')
-    print('\n\n\n',layer.copy(),'\n\n\n')
+    print('\n\n\n',layer.moe_op,'\n\n\n')
     
     
     return layer

--- a/vllm_hpu_extension/ops.py
+++ b/vllm_hpu_extension/ops.py
@@ -849,7 +849,7 @@ def fp8_channel_moe_prepare_weights(layer):
     htorch.core.mark_step()
     
     
-    print('\n\n\n',os.getenv("VLLM_HPU_FORCE_HUNYUAN_FP8"),'\n\n\n')
+    print('\n\n\n',os.environ.copy(),'\n\n\n')
     
     
     return layer

--- a/vllm_hpu_extension/ops.py
+++ b/vllm_hpu_extension/ops.py
@@ -839,7 +839,7 @@ def fp8_channel_moe_prepare_weights(layer):
             layer.moe_op.w2_list[index].set_scale_inv_fp8(weight_scale_inv)
         
         # change the scalar scale_inv_fp8 to meet the channel size
-        if len(layer.moe_op.w2_list[index].scale_inv_fp8.shape) == 1:
+        if len(layer.moe_op.w2_list[index].scale_inv_fp8) == 0 and len(layer.moe_op.w13_list[index].scale_inv_fp8) == 1:
             layer.moe_op.w2_list[index].set_scale_inv_fp8(layer.moe_op.w2_list[index].scale_inv_fp8.repeat(layer.w2_weight.shape[1]).flatten().clone())
             layer.moe_op.w13_list[index].set_scale_inv_fp8(layer.moe_op.w13_list[index].scale_inv_fp8.reshape(2,1).repeat(1,layer.w13_weight.shape[1]//2).flatten().clone())
             

--- a/vllm_hpu_extension/ops.py
+++ b/vllm_hpu_extension/ops.py
@@ -849,7 +849,7 @@ def fp8_channel_moe_prepare_weights(layer):
     htorch.core.mark_step()
     
     
-    print('\n\n\n',layer.moe_op,'\n\n\n')
+    print('\n\n\n', layer.moe_op.w13_list[0].weight.shape, layer.moe_op.w2_list[0].weight.shape, '\n\n\n')
     
     
     return layer

--- a/vllm_hpu_extension/ops.py
+++ b/vllm_hpu_extension/ops.py
@@ -850,7 +850,14 @@ def fp8_channel_moe_prepare_weights(layer):
     
     
     #print('\n\n\n', layer.moe_op.w13_list[0].weight.shape, layer.moe_op.w2_list[0].weight.shape, '\n\n\n')
-    print('\n\n\n', get_config(), '\n\n\n')
+    import pprint
+    cfg = get_config()
+    attrs = {k: getattr(cfg, k)
+                for k in dir(cfg)
+                if not k.startswith("_") and not callable(getattr(cfg, k))}
+    print('\n\n\n')
+    pprint.pprint(attrs)
+    print('\n\n\n')
     
     
     return layer

--- a/vllm_hpu_extension/ops.py
+++ b/vllm_hpu_extension/ops.py
@@ -850,14 +850,8 @@ def fp8_channel_moe_prepare_weights(layer):
     
     
     #print('\n\n\n', layer.moe_op.w13_list[0].weight.shape, layer.moe_op.w2_list[0].weight.shape, '\n\n\n')
-    import pprint
     cfg = get_config()
-    attrs = {k: getattr(cfg, k)
-                for k in dir(cfg)
-                if not k.startswith("_") and not callable(getattr(cfg, k))}
-    print('\n\n\n')
-    pprint.pprint(attrs)
-    print('\n\n\n')
+    print('\n\n\n', cfg.get_all(), '\n\n\n')
     
     
     return layer

--- a/vllm_hpu_extension/ops.py
+++ b/vllm_hpu_extension/ops.py
@@ -849,7 +849,7 @@ def fp8_channel_moe_prepare_weights(layer):
     htorch.core.mark_step()
     
     
-    print('\n\n\n',os.environ.copy(),'\n\n\n')
+    print('\n\n\n',layer,'\n\n\n')
     
     
     return layer

--- a/vllm_hpu_extension/ops.py
+++ b/vllm_hpu_extension/ops.py
@@ -542,7 +542,6 @@ class VllmMixtureOfExpertsOp(torch.nn.Module):
             experts_max=self.experts_max,
             **kwargs
         )
-        print('\nVllmMixtureOfExpertsOp\n')
         return final_hidden_states
 
 
@@ -568,7 +567,6 @@ class DynamicFusedMOE(torch.nn.Module):
             permuted_weights=True,
             activation="silu",
         )
-        print('\nDynamicFusedMOE\n')
 
         return final_hidden_states.view(-1, hidden_states.shape[1])
 
@@ -967,7 +965,6 @@ class VllmMixtureOfExpertsOpFP8(torch.nn.Module):
             experts_max=self.experts_max,
             **kwargs
         )
-        print('\nVllmMixtureOfExpertsOpFP8\n')
         return final_hidden_states
 
 
@@ -1060,7 +1057,7 @@ class VllmMixtureOfExpertsOpFP8PerChannel(torch.nn.Module):
                                     experts_min=self.experts_min,
                                     experts_max=self.experts_max,
                                     **kwargs)
-        print('\nVllmMixtureOfExpertsOpFP8PerChannel\n')
+
         return final_hidden_states
 
 

--- a/vllm_hpu_extension/ops.py
+++ b/vllm_hpu_extension/ops.py
@@ -839,8 +839,8 @@ def fp8_channel_moe_prepare_weights(layer):
             layer.moe_op.w2_list[index].set_scale_inv_fp8(weight_scale_inv)
         
         if get_config().model_type == "hunyuan":
-            layer.moe_op.w2_list[index].set_scale_inv_fp8(layer.moe_op.w2_list[index].scale_inv_fp8.repeat(4096).flatten().clone())
-            layer.moe_op.w13_list[index].set_scale_inv_fp8(layer.moe_op.w13_list[index].scale_inv_fp8.reshape(2,1).repeat(1,3072).flatten().clone())
+            layer.moe_op.w2_list[index].set_scale_inv_fp8(layer.moe_op.w2_list[index].scale_inv_fp8.repeat(layer.w2_weight.shape[1]).flatten().clone())
+            layer.moe_op.w13_list[index].set_scale_inv_fp8(layer.moe_op.w13_list[index].scale_inv_fp8.reshape(2,1).repeat(1,layer.w13_weight.shape[1]//2).flatten().clone())
             
     if hasattr(layer, "w13_input_scale"):
         layer.moe_op.w13_input_scale = layer.w13_input_scale


### PR DESCRIPTION
### Summary
This PR fixes the scaling issue for models like **Hunyuan**:
- `w2_scale_fp8` is provided as a scalar, but should be expanded to match the per-channel size.
- `w13_scale_fp8` is given in a combined form (two values for W1/W3) and needs to be reshaped and repeated to the correct size for per-channel quantization.
- Ensures that `w2_input_scale` is stored as a list (one per expert) instead of a single tensor.
