### PR TITLE
Remove the NaN checking for the fp8 weights

### DIFF
--- a/vllm_hpu_extension/ops.py
+++ b/vllm_hpu_extension/ops.py
@@ -743,9 +743,6 @@ def dynamic_quant(data, single_scale = False):
 
 
 def fp8_block_linear_postprocess_weights(layer, force_channel_fp8=False):
-    if torch.isnan(layer.weight.data).any():
-        raise ValueError("NaN detected in weights. Please use the flag VLLM_HPU_CONVERT_TO_FP8UZ to convert it at runtime or" \
-        " convert the weights using scripts/deepseek_gaudi2 from vllm-hpu-extension")
     weight, orig_M, orig_N = pad_block_fp8_weight_naive(
         layer.weight.data,
         layer.weight_scale_inv.data,
@@ -776,9 +773,6 @@ def fp8_block_linear_postprocess_weights(layer, force_channel_fp8=False):
 
 
 def fp8_block_moe_prepare_weights(layer, force_channel_fp8=False):
-    if torch.isnan(layer.w13_weight.data).any():
-        raise ValueError("NaN detected in weights. Please use the flag VLLM_HPU_CONVERT_TO_FP8UZ to convert it at runtime or" \
-        " convert the weights using scripts/deepseek_gaudi2 from vllm-hpu-extension")
     if force_channel_fp8:
         # convert to channel-wise fp8
         w13_weight, w13_weight_scale_inv = dynamic_quant(dequant_block_fp8_weight_naive(


### PR DESCRIPTION
Remove the NaN checking for the fp8 weights as
- it cause extra HPU memory consumption,
- and `VLLM_HPU_CONVERT_TO_FP8UZ` will be set automatically after https://github.com/HabanaAI/vllm-fork/pull/1866