### PR TITLE
limit the warmup range by the `bucket_max`

### DIFF
--- a/vllm_hpu_extension/bucketing/linear.py
+++ b/vllm_hpu_extension/bucketing/linear.py
@@ -128,8 +128,6 @@ def warmup_range_with_limit(config: Tuple[int, int, int, float]):
             next_bucket = last_bucket * 2
             if next_bucket <= bucket_max:
                 buckets.append(next_bucket)
-            else:
-                break
         else:
             next_bucket = current_bucket + bucket_step
             max_padding_ratio = 1 - (last_bucket / (next_bucket  - 1))

--- a/vllm_hpu_extension/bucketing/linear.py
+++ b/vllm_hpu_extension/bucketing/linear.py
@@ -126,7 +126,10 @@ def warmup_range_with_limit(config: Tuple[int, int, int, float]):
         last_bucket = buckets[-1]
         if current_bucket <= bucket_step:
             next_bucket = last_bucket * 2
-            buckets.append(next_bucket)
+            if next_bucket <= bucket_max:
+                buckets.append(next_bucket)
+            else:
+                break
         else:
             next_bucket = current_bucket + bucket_step
             max_padding_ratio = 1 - (last_bucket / (next_bucket  - 1))


### PR DESCRIPTION
Current implementation will generate `(1, 2, 1)` for a config with `[min, step, max, limit]=[1, 1, 1, 0.25]`. This PR limits the warmup range by the `bucket_max` and will generate the expected `(1)` in this case.