### PR TITLE
[SW-238300] Disabling dynamic quantization in mlp module

### DIFF
--- a/quantization_config/maxabs_quant_dynamic_quantization.json
+++ b/quantization_config/maxabs_quant_dynamic_quantization.json
@@ -3,6 +3,12 @@
     "observer": "maxabs",
     "scale_format": "CONST",
     "scale_method": "act_maxabs_pcs_pow2_weight_maxabs_pts_pow2_hw",
+    "allowlist": {
+        "types": [],
+        "names": [
+            "mlp"
+        ]
+    },
     "dynamic_quantization": true,
     "dump_stats_path": ""
 }


### PR DESCRIPTION
The fix was reverted in 1.23 due to other issues, so we need to disable dynamic quantization in mlp also for 1.23.0
Reverted fix:
https://github.com/habana-internal/synapse/pull/2182

Original issue:
https://jira.habana-labs.com/browse/SW-238300