### PR TITLE
Block matmul and kv_cache in dynamic quantization

### DIFF
--- a/quantization_config/maxabs_quant_dynamic_quantization.json
+++ b/quantization_config/maxabs_quant_dynamic_quantization.json
@@ -9,12 +9,6 @@
             "Matmul",
             "KVCache",
             "VLLMKVCache"
-        ],
-        "names": [
-            "matmul_qk",
-            "matmul_av",
-            "k_cache",
-            "v_cache"
         ]
     },
     "dump_stats_path": ""

--- a/quantization_config/maxabs_quant_dynamic_quantization.json
+++ b/quantization_config/maxabs_quant_dynamic_quantization.json
@@ -4,5 +4,18 @@
     "scale_format": "CONST",
     "scale_method": "act_maxabs_pcs_pow2_weight_maxabs_pts_pow2_hw",
     "dynamic_quantization": true,
+    "blocklist": {
+        "types": [
+            "Matmul",
+            "KVCache",
+            "VLLMKVCache"
+        ],
+        "names": [
+            "matmul_qk",
+            "matmul_av",
+            "k_cache",
+            "v_cache"
+        ]
+    },
     "dump_stats_path": ""
 }


### PR DESCRIPTION
Currently disabling matmul and kv_cache in dynamic quantization mode