### PR TITLE
Use fp8 FusedSDPA for qwen3 MoE models

### DIFF
--- a/calibration/calibrate_model.sh
+++ b/calibration/calibrate_model.sh
@@ -141,36 +141,37 @@ create_quant_config() {
     block_names="[\"lm_head\", \"mlp\\\\.gate\\\\b\", \"visual\"]"
     fp8_config="E4M3"
     scale_format="scalar"
-    block_types_bf16_attn="[\"VLLMKVCache\", \"Matmul\", \"Softmax\"]"
-    block_names_bf16_attn="[\"lm_head\", \"mlp\\\\.gate\\\\b\", \"visual\", \"fused_scaled_dot_product_attention\"]"
-    if [[ $model_name_lower == *"deepseek-r1-distill-qwen-7b"* \
-            || $model_name_lower == *"qwen2-7b-instruct"* \
-            || $model_name_lower == *"qwen2.5-7b-instruct"* ]]; then
+    block_types_bf16_decoding="[\"VLLMKVCache\", \"Matmul\", \"Softmax\"]"
+    block_names_bf16_prefill="[\"lm_head\", \"mlp\\\\.gate\\\\b\", \"visual\", \"fused_scaled_dot_product_attention\"]"
+    if [[ $model_name_lower == *"qwen-7b"* \
+            || $model_name_lower == *"qwen2-7b"* \
+            || $model_name_lower == *"qwen2.5-7b"* ]]; then
         export VLLM_FP32_SOFTMAX=true
         scale_method="unit_scale"
-        block_types="$block_types_bf16_attn"
-        block_names="$block_names_bf16_attn"
+        block_types="$block_types_bf16_decoding"
+        block_names="$block_names_bf16_prefill"
     elif [[ $model_name_lower =~ ^mixtral ]]; then
         scale_format="const"
-        block_types="$block_types_bf16_attn"
-        block_names="$block_names_bf16_attn"
+        block_types="$block_types_bf16_decoding"
+        block_names="$block_names_bf16_prefill"
     elif [[ $model_name_lower == *"deepseek-r1-distill-llama-8b"* ]]; then
-        block_types="$block_types_bf16_attn"
-        block_names="$block_names_bf16_attn"
+        block_types="$block_types_bf16_decoding"
+        block_names="$block_names_bf16_prefill"
     elif [[ $model_name_lower == *"qwen3"* && $model_name_lower != *"qwen3-32b"* ]]; then
-        block_types="$block_types_bf16_attn"
-        block_names="$block_names_bf16_attn"
-        if [[ $model_name_lower == *"qwen3-30b-a3b"* \
-            || $model_name_lower == *"qwen3-235b-a22b"* \
+        block_types="$block_types_bf16_decoding"
+        if [[ $model_name_lower == *"30b-a3b"* \
+            || $model_name_lower == *"235b-a22b"* \
+            || $model_name_lower == *"480b-a35b"* \
             ]]; then
             scale_format="const"
+        else
+            block_names="$block_names_bf16_prefill"
         fi
     fi
     
     if [[ $model_name_lower == *"glm-4."* ]]; then
         scale_format="const"
-        block_types="$block_types_bf16_attn"
-        block_names="[\"lm_head\", \"mlp\\\\.gate\\\\b\"]"
+        block_types="$block_types_bf16_decoding"
     fi
 
     if [[ $scale_format == "const" ]]; then


### PR DESCRIPTION
Use fp8 FusedSDPA for `qwen3*[30b-a3b|235b-a22b|480b-a35b]*` models.