### PR TITLE
Fix sliced FusedSDPA accuracy and context bucketing for chunked-prefill

### DIFF
--- a/vllm_hpu_extension/bucketing/common.py
+++ b/vllm_hpu_extension/bucketing/common.py
@@ -143,7 +143,7 @@ class HPUBucketingManager():
     def find_prompt_bucket(self, batch_size, seq_len, ctx=0, use_fallback=True):
         target_shape = (batch_size, seq_len, ctx)
         if self.initialized:
-            if get_config().prefix_caching:
+            if get_config().prefix_caching or get_config().chunked_prefill:
                 found_bucket = find_bucket_with_prefix_caching(self.prompt_buckets, target_shape, self.block_size)
             else:
                 found_bucket = find_equal_or_closest_greater_config(self.prompt_buckets, target_shape)

--- a/vllm_hpu_extension/utils.py
+++ b/vllm_hpu_extension/utils.py
@@ -663,23 +663,22 @@ class CausalSDPA(torch.autograd.Function):
             query, key, value, attn_mask = gqa_input_reshape_fwd(
                 query, key, value, attn_mask)
 
-        # Kernel limitation, need to use not causal and pass mask to get correct m and linv
-        if query_len % 1024 != 0:
-            is_causal = False
-            if attn_mask is None:
-                bs = query.size(0)
-                mask_shape = (bs, 1, 1, query_len,
-                              query_len) if gqa else (bs, 1, query_len,
-                                                      query_len)
-                mask = (1 - torch.tril(
-                    torch.ones(
-                        mask_shape, dtype=query.dtype,
-                        device=query.device))) * torch.finfo(query.dtype).min
-            else:
-                mask = attn_mask
+        # Always run with is_causal=False and an explicit mask. The kernel's
+        # is_causal=True path uses a different internal algorithm that diverges
+        # from the explicit-mask path for the returned m and linv. Since these
+        # values are combined via online-softmax rescaling with the non-causal
+        # prefix chunk, the inconsistency corrupts the output and drops accuracy.
+        if attn_mask is None:
+            bs = query.size(0)
+            mask_shape = (bs, 1, 1, query_len,
+                          query_len) if gqa else (bs, 1, query_len,
+                                                  query_len)
+            mask = (1 - torch.tril(
+                torch.ones(
+                    mask_shape, dtype=query.dtype,
+                    device=query.device))) * torch.finfo(query.dtype).min
         else:
-            is_causal = True
-            mask = None
+            mask = attn_mask
 
         result = torch.ops.hpu.sdpa_recomp_fwd(
             query,
@@ -688,7 +687,7 @@ class CausalSDPA(torch.autograd.Function):
             mask,  #attn_mask
             0.0,  #dropout
             scale,
-            is_causal,  #is_causal
+            False,  #is_causal
             True,  #requires_backward
             softmax_mode,
             valid_seq_len,
@@ -764,50 +763,41 @@ class QKVSliceCausalSDPA(torch.autograd.Function):
                 value_slice = value_slice.clone()
                 htorch.core.mark_step()
             
-            # Kernel limitation, need to use not causal and pass mask to get correct m and linv
-            if q_slice_len % 1024 != 0 or q_slice_len < chunk_size:
-                if attn_mask is not None:
-                    mask = attn_mask[..., query_start:query_end,
-                                     query_start:query_end]
-                    if with_mark_step:
-                        mask = mask.clone()
-                        htorch.core.mark_step()
-                else:
-                    mask_shape = (bs, 1, 1, q_slice_len,
-                                  q_slice_len) if gqa else (bs, 1, q_slice_len,
-                                                            q_slice_len)
-                    mask = (1 - torch.tril(
-                        torch.ones(mask_shape,
-                                   dtype=query.dtype,
-                                   device=query.device))) * torch.finfo(
-                                       query.dtype).min
-
-                result = torch.ops.hpu.sdpa_recomp_fwd(
-                    query_slice,
-                    key_slice,
-                    value_slice,
-                    mask,
-                    0.0,  #dropout
-                    scale,
-                    False,  #is_causal
-                    True,  #requires_backward
-                    softmax_mode,
-                    None,  #valid_seq_len
-                    padding_mode)
+            # Always pass an explicit mask for the diagonal chunk and run with
+            # is_causal=False. The kernel's is_causal=True path uses a different
+            # internal algorithm that diverges from the explicit-mask path for
+            # the returned m and linv, even when both encode the same triangular
+            # pattern. Since these m/linv values are combined via online-softmax
+            # rescaling with the non-causal (masked) prefix and cross chunks,
+            # the inconsistency corrupts the output and drops accuracy.
+            if attn_mask is not None:
+                mask = attn_mask[..., query_start:query_end,
+                                 query_start:query_end]
+                if with_mark_step:
+                    mask = mask.clone()
+                    htorch.core.mark_step()
             else:
-                # causal
-                result = torch.ops.hpu.sdpa_recomp_fwd(
-                    query_slice,
-                    key_slice,
-                    value_slice,
-                    None,  #mask
-                    0.0,  #dropout
-                    scale,
-                    True,  #is_causal
-                    True,  #requires_backward
-                    softmax_mode,
-                    None,  #valid_seq_len
-                    padding_mode)
+                mask_shape = (bs, 1, 1, q_slice_len,
+                              q_slice_len) if gqa else (bs, 1, q_slice_len,
+                                                        q_slice_len)
+                mask = (1 - torch.tril(
+                    torch.ones(mask_shape,
+                               dtype=query.dtype,
+                               device=query.device))) * torch.finfo(
+                                   query.dtype).min
+
+            result = torch.ops.hpu.sdpa_recomp_fwd(
+                query_slice,
+                key_slice,
+                value_slice,
+                mask,
+                0.0,  #dropout
+                scale,
+                False,  #is_causal
+                True,  #requires_backward
+                softmax_mode,
+                None,  #valid_seq_len
+                padding_mode)
 
             out, m, linv = (gqa_output_reshape(x) if gqa else x
                             for x in result[:3])


### PR DESCRIPTION
This PR contains two related fixes for the sliced FusedSDPA / chunked-prefill accuracy issue observed on LongBench (Qwen3-235B-A22B drops from **0.4872** to **0.408** when `VLLM_HPU_FSDPA_SLICE_SEQ_LEN_THLD=8192`).

---

## 1. Fix sliced FusedSDPA accuracy drop from inconsistent causal m/linv

### Root cause
The FusedSDPA kernel computes the softmax statistics `m` (row-max) and `linv` (1/sum) using a **different internal algorithm** on the `is_causal=True` path than on the explicit-mask path. The sliced implementation combines per-chunk outputs via flash-attention online-softmax rescaling, which requires `m`/`linv` to be numerically consistent **across** chunks.

In `QKVSliceCausalSDPA` (and `CausalSDPA`), the diagonal causal chunk used `is_causal=True` with `mask=None`, while the prefix and cross chunks used the explicit-mask path. The stats diverged, corrupting the combined output and dropping accuracy.

### Fix
For the diagonal/causal chunk, always pass an explicit triangular mask and run with `is_causal=False`, so its `m`/`linv` match the masked chunks it is combined with. Fully-visible cross chunks keep `mask=None` for speed, so the perf cost is bounded to the diagonal chunk only.

This mirrors the merged upstream fix in vllm-gaudi PR #1438. The `USING_INC`/dispatch restructuring from that PR is not needed here: our `ops.py` flips `is_causal -> False` unconditionally and the slice path dispatches on shape rather than `is_causal`.

Changes:
- `QKVSliceCausalSDPA`: diagonal chunk always uses explicit mask + `is_causal=False`
- `CausalSDPA`: same fix for the `split_kv` / `slice_causal` impls

---

## 2. Fix context bucketing for chunked-prefill without prefix-caching

`find_prompt_bucket` only used `find_bucket_with_prefix_caching` when `prefix_caching` was enabled. With chunked-prefill (and no prefix-caching), it fell back to `find_equal_or_closest_greater_config`, which does not block-align / truncate the context length the way the sliced path expects. This produced mismatched context buckets for the chunked-prefill runs.

Fix: also route through `find_bucket_with_prefix_caching` when `chunked_prefill` is enabled.

Changes:
- `bucketing/common.py`: `find_prompt_bucket` uses prefix-caching bucketing for `prefix_caching or chunked_prefill`